### PR TITLE
(続) active storageのprod環境の保存先をS3に

### DIFF
--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -1,5 +1,6 @@
 require 'aws-sdk'
 
-if Rails.env.production?
+# ECS環境での実行時のみECSCredentialsを使用する
+if ENV['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'].present?
   Aws.config.update({ credentials: Aws::ECSCredentials.new })
 end


### PR DESCRIPTION
## 概要
- [このPRの続き](https://github.com/sarii0213/lean_up/pull/83)（PRマージ後deployに失敗していたので修正したもの）


## 詳細
- ECSの認証情報取得を、本番環境で行うように条件分岐していたため、build時に認証情報取得を試みてしまっていた。今回の修正でECS環境でのみ設定される環境変数をもとに条件分岐させることで、build時には認証情報取得はされないのではと思う。

