### PR TITLE
ログイン関連機能のnotice, alertを正しく表示

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,4 +3,10 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+
+  private
+
+  def after_sign_out_path_for(resource_or_scope)
+    login_path
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
 
   private
 
-  def after_sign_out_path_for(resource_or_scope)
+  def after_sign_out_path_for(_resource_or_scope)
     login_path
   end
 end


### PR DESCRIPTION
## 概要
- ログアウト後のフラッシュメッセージの修正
- close #87 

## UIの変更
before （ログアウト直後）
<img width="847" alt="スクリーンショット 2025-04-13 9 52 43" src="https://github.com/user-attachments/assets/f5aef791-1911-4f65-a869-820e7c0bb18d" />


after （ログアウト直後）
<img width="759" alt="スクリーンショット 2025-04-13 10 10 57" src="https://github.com/user-attachments/assets/2137d393-97b2-4db5-98a1-48bc3c05551f" />


## 詳細
- sessions#destroy内で、リダイレクト先に指定されている`after_sign_out_path_for`をルートパスからログインパスに修正（[devise github sessions#destroy](https://github.com/heartcombo/devise/blob/fec67f98f26fcd9a79072e4581b1bd40d0c7fa1d/app/controllers/devise/sessions_controller.rb#L80)）


