### PR TITLE
パスワード忘れた用画面のUIを整える

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,6 +82,7 @@ end
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem 'web-console'
+  gem 'letter_opener_web'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -81,8 +81,8 @@ end
 
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
-  gem 'web-console'
   gem 'letter_opener_web'
+  gem 'web-console'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1728,6 +1728,8 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     chartkick (5.1.4)
+    childprocess (5.1.0)
+      logger (~> 1.5)
     concurrent-ruby (1.3.4)
     connection_pool (2.5.0)
     crass (1.0.6)
@@ -1800,6 +1802,17 @@ GEM
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
     language_server-protocol (3.17.0.4)
+    launchy (3.1.1)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
+      logger (~> 1.6)
+    letter_opener (1.10.0)
+      launchy (>= 2.2, < 4)
+    letter_opener_web (3.0.0)
+      actionmailer (>= 6.1)
+      letter_opener (~> 1.9)
+      railties (>= 6.1)
+      rexml
     lint_roller (1.1.0)
     logger (1.7.0)
     loofah (2.24.0)
@@ -2061,6 +2074,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   kaminari
+  letter_opener_web
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.2.2)

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,16 +1,31 @@
-<h2><%= t('.forgot_your_password') %></h2>
+<div class="ui middle aligned center aligned grid">
+  <div class="column" style="max-width: 450px;">
+    <h2 class="ui teal image header">
+      <div class="content">
+        Reset your password
+      </div>
+    </h2>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, class: 'ui large form' }) do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
+      <div class="ui stacked segment field">
+        <div class="field">
+          <div class="ui left icon input">
+            <i class="user icon"></i>
+            <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: 'email' %>
+          </div>
+        </div>
 
-  <div class="field">
-    <%= f.label :email %><br>
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+        <%= f.submit t('.send_me_reset_password_instructions'), class: 'actions ui fluid large teal submit button' %>
+      </div>
+
+      <% if alert %>
+        <div class="ui error message"><%= alert %></div>
+      <% end %>
+    <% end %>
+
+    <div class="ui message">
+      <%= render "devise/shared/links" %>
+    </div>
   </div>
-
-  <div class="actions">
-    <%= f.submit t('.send_me_reset_password_instructions') %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -45,6 +45,7 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
 
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
+  config.action_mailer.delivery_method = :letter_opener_web
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,4 +31,8 @@ Rails.application.routes.draw do
   resources :records, only: %i[index new update]
   resource :user_setting, only: %i[show edit update]
   resources :periods
+
+  if Rails.env.development?
+    mount LetterOpenerWeb::Engine, at: "/letter_opener"
+  end
 end

--- a/db/Schemafile
+++ b/db/Schemafile
@@ -1,4 +1,4 @@
-create_table "users", id: :bigint, force: :cascade do |t|
+create_table "users", force: :cascade do |t|
   t.string "username", limit: 191, default: ""
   t.string "email", limit: 191, default: "", null: false
   t.decimal "goal_weight"
@@ -8,45 +8,45 @@ create_table "users", id: :bigint, force: :cascade do |t|
   t.string "encrypted_password", default: "", null: false
   t.string "reset_password_token"
   t.datetime "reset_password_sent_at"
-  t.datetime "updated_at", precision: 6, null: false
-  t.datetime "created_at", precision: 6, null: false
+  t.datetime "updated_at", null: false
+  t.datetime "created_at", null: false
   t.datetime "remember_created_at"
 
   add_index "users", ["email"], unique: true
   add_index "users", ["reset_password_token"], unique: true
 end
 
-create_table "objectives", id: :bigint, force: :cascade do |t|
+create_table "objectives", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.integer "objective_type", null: false
     t.string "verbal"
     t.text "comment"
     t.integer "order"
-    t.datetime "updated_at", precision: 6, null: false
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", null: false
+    t.datetime "created_at", null: false
 
     add_index "objectives", ["user_id", "order"]
     add_foreign_key "objectives", "users"
 end
 
-create_table "records", id: :bigint, force: :cascade do |t|
+create_table "records", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.date "recorded_on", null: false
     t.decimal "weight", null: false
     t.decimal "body_fat"
-    t.datetime "updated_at", precision: 6, null: false
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", null: false
+    t.datetime "created_at", null: false
 
     add_index "records", ["user_id", "recorded_on"], unique: true
     add_foreign_key "records", "users"
 end
 
-create_table "periods", id: :bigint, force: :cascade do |t|
+create_table "periods", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.date "started_on", null: false
     t.date "ended_on", null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", null: false
+    t.datetime "created_at", null: false
 
     add_index "periods", ["user_id", "started_on"], unique: true
     add_foreign_key "periods", "users"


### PR DESCRIPTION
## 概要
- deviseのデフォルトのパスワード忘れ画面のUIにスタイル適用
- close #89 

## UIの変更　
before（パスワード忘れ画面）
![スクリーンショット 2025-04-14 16 59 25](https://github.com/user-attachments/assets/8f85ad10-4ba1-4c8d-8054-94e65d33257b)

after（パスワード忘れ画面）
<img width="519" alt="スクリーンショット 2025-04-15 16 50 52" src="https://github.com/user-attachments/assets/d5ac82cc-e34c-4199-b2c7-da19027a200c" />



## 追加したgem
- [letter_opener_web](https://github.com/fgrehm/letter_opener_web)
　（パスワード忘れるとメール送る仕様の確認のため）

## その他
- SchemafileとDBのテーブル構造に差異が生まれてしまっていた（datetimeのprecision & tableのid）ので、テーブル構造をexportした形と合うようにSchemafileを書き換えた。
