### PR TITLE
スマホでの表示の改善（レスポンシブデザイン）

### DIFF
--- a/app/assets/stylesheets/_sp.scss
+++ b/app/assets/stylesheets/_sp.scss
@@ -1,0 +1,5 @@
+@media screen and (max-width: 1080px) {
+  input[type=email], input[type=password], textarea, input[type=text] {
+    font-size: 16px !important;
+  }
+}

--- a/app/assets/stylesheets/_sp.scss
+++ b/app/assets/stylesheets/_sp.scss
@@ -1,5 +1,11 @@
 @media screen and (max-width: 1080px) {
+
   input[type=email], input[type=password], textarea, input[type=text] {
     font-size: 16px !important;
+  }
+
+  .sp-column {
+    flex-direction: column !important;
+    justify-content: space-around !important;
   }
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,2 +1,3 @@
 @import 'reset';
 @import 'semantic-ui';
+@import 'sp';

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -9,6 +9,10 @@
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, class: 'ui large form' }) do |f| %>
       <%= render "devise/shared/error_messages", resource: resource %>
 
+      <div style="font-size:0.8rem;color:#888;text-align:left;margin-bottom:10px;">
+        <p>メールアドレスのみを変更する場合：<br>新メールアドレス, 一番下に現在のパスワードを入力してください。</p>
+        <p>パスワードを変更する場合：<br>新パスワード（6文字以上）, 新パスワード（確認用）, 現在のパスワードを入力してください。</p>
+      </div>
       <div class="ui stacked segment field">
         <div class="field">
           <div class="ui left icon input">
@@ -25,21 +29,21 @@
           <div class="ui left icon input">
             <i class="lock icon"></i>
             <%= f.password_field :password, autocomplete: "new-password",
-                                 placeholder: "password #{@minimum_password_length ? t('devise.shared.minimum_password_length', count: @minimum_password_length) : '' }  (#{t('.leave_blank_if_you_don_t_want_to_change_it')})" %>
+                                 placeholder: "new password" %>
           </div>
         </div>
 
         <div class="field">
           <div class="ui left icon input">
             <i class="lock icon"></i>
-            <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: 'password for confirmation' %>
+            <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: 'new password for confirmation' %>
           </div>
         </div>
 
         <div class="field">
           <div class="ui left icon input">
             <i class="lock icon"></i>
-            <%= f.password_field :password, autocomplete: "current-password", placeholder: "password (#{t('.we_need_your_current_password_to_confirm_your_changes')})" %>
+            <%= f.password_field :password, autocomplete: "current-password", placeholder: "current password" %>
           </div>
         </div>
 

--- a/app/views/objectives/_objective.html.erb
+++ b/app/views/objectives/_objective.html.erb
@@ -12,7 +12,7 @@
     <div>
       <% if objective.images %>
         <% objective.images.each do |image| %>
-          <%= image_tag image.variant(:large) %>
+          <%= image_tag image.variant(:large), style: 'width: 100%' %>
         <% end %>
       <% end %>
     </div>

--- a/app/views/objectives/show.html.erb
+++ b/app/views/objectives/show.html.erb
@@ -8,15 +8,15 @@
   <div class="ui horizontal segments">
     <%= link_to edit_objective_path(@objective), class: 'ui segment' do %>
       <i class="edit icon"></i>
-      編集する
+      編集
     <% end %>
     <%= link_to objectives_path, class: 'ui segment' do %>
       <i class="list ui icon"></i>
-      一覧に戻る
+      一覧へ
     <% end %>
     <%= link_to @objective, class: 'ui segment', data: { turbo_method: :delete, turbo_confirm: '削除しますか？' } do %>
       <i class="trash alternate icon"></i>
-      削除する
+      削除
     <% end %>
   </div>
 </div>

--- a/app/views/periods/_period.html.erb
+++ b/app/views/periods/_period.html.erb
@@ -1,7 +1,6 @@
 <div style="display: flex; justify-content: space-between; padding-right: 10px">
   <span><%= period.started_on %>　-　<%= period.ended_on %></span>
   <div>
-    <%# TODO: edit, deleteをiconに %>
     <%= link_to edit_period_path(period), data: { turbo_frame: period } do %>
       <i class="edit icon"></i>
     <% end %>

--- a/app/views/periods/edit.html.erb
+++ b/app/views/periods/edit.html.erb
@@ -1,7 +1,7 @@
 <%= turbo_frame_tag @period do %>
   <%= form_with model: @period, method: :put, class: "ui form #{@period.errors.any? ? 'error' : ''}" do |f| %>
     <div style="display: flex;  justify-content: space-between">
-      <div style="display: flex; align-items: center;">
+      <div style="display: flex; align-items: center;" class="sp-column">
         <div class="inline field" style="margin:0">
           <%= f.date_field :started_on %>
         </div>
@@ -10,7 +10,7 @@
           <%= f.date_field :ended_on %>
         </div>
       </div>
-      <div style="display: flex; align-items: center">
+      <div style="display: flex; align-items: center" class="sp-column">
         <%= f.submit '更新', class: 'ui mini button' %>
         <%= link_to 'キャンセル', periods_path, class: 'ui mini button' %>
       </div>

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -15,7 +15,6 @@ if [ "${1}" == "./bin/rails" ] && [ "${2}" == "server" ]; then
 
   if [ "$RAILS_ENV" == "development" ]; then
     bundle exec rake ridgepole:apply
-    bundle exec rake db:seed_fu
   fi
 fi
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -84,4 +84,6 @@ Rails.application.configure do
   # config.generators.apply_rubocop_autocorrect_after_generate!
 
   config.action_mailer.default_url_options = { host: 'localhost', port: 3006 }
+
+  config.hosts << '.ngrok-free.app'
 end


### PR DESCRIPTION
## 概要
- スマホ（iPhone）でのスタイル崩れを修正した
- close #91 

## UIの変更

|     |  before   |  after   |
|---|---|---|
|  ログイン直後   |  ![IMG_3646](https://github.com/user-attachments/assets/b24c2691-7237-484a-9989-8396cc5e2db5)   |  ![Screenshot 2025-04-16 at 18 56 20](https://github.com/user-attachments/assets/45ccc29f-99be-4a07-b639-37740611bf76) |
|  ログイン情報の編集画面   |  ![IMG_3654](https://github.com/user-attachments/assets/8f50c621-3cd0-4d50-b5af-1838f0e612d5) |  ![IMG_3648](https://github.com/user-attachments/assets/de33d740-0d14-4d7d-95fd-eb86e15927c8) |
|   生理期間の編集画面  |  ![IMG_3655](https://github.com/user-attachments/assets/700e043f-0140-4d13-8730-d046dc108af1)   |  ![IMG_3649](https://github.com/user-attachments/assets/aacc920e-05d2-4fa0-88d1-b0f891af6429) |


## 詳細
- スマホで16px未満のフォントサイズだと画面が拡大され、入力後も拡大率が維持されてしまうため、表示が崩れていた
- 横幅が短くはみ出てしまうところは、flex directionを横から縦に変えるなどレスポンシブにした

## その他
- docker-entrypointにて、docker起動のたびにdb:seed_fuを行っていたためにユニーク制約違反のエラーが出ていたのでdocker-entrypointから削除。今後はseed変更のたびにdb:seed_fuを手動で行う
- スマホでのUIの確認は、ngrokを導入して行った
