### PR TITLE
[vision board] 表示順の調整機能を追加

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,9 @@ Style/Documentation:
 RSpec/ContextWording:
   Enabled: false
 
+RSpec/MultipleExpectations:
+  Enabled: false
+
 Lint/MissingSuper:
   AllowedParentClasses:
     - ViewComponent::Base

--- a/app/assets/stylesheets/_objectives.scss
+++ b/app/assets/stylesheets/_objectives.scss
@@ -1,0 +1,5 @@
+#order_icons {
+    form {
+        display: inline-block;
+    }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,3 +1,4 @@
 @import 'reset';
 @import 'semantic-ui';
 @import 'sp';
+@import 'objectives';

--- a/app/controllers/objectives_controller.rb
+++ b/app/controllers/objectives_controller.rb
@@ -5,7 +5,7 @@ class ObjectivesController < ApplicationController
   before_action :set_objective, only: %i[show edit update destroy]
 
   def index
-    @objectives = current_user.objectives.order(updated_at: :desc).page(params[:page]).per(5)
+    @objectives = current_user.objectives.order(order: :desc).page(params[:page]).per(5)
   end
 
   def show; end

--- a/app/controllers/objectives_controller.rb
+++ b/app/controllers/objectives_controller.rb
@@ -6,6 +6,7 @@ class ObjectivesController < ApplicationController
 
   def index
     @objectives = current_user.objectives.order(order: :desc)
+    @maximum = @objectives.maximum(:order)
   end
 
   def show; end

--- a/app/controllers/objectives_controller.rb
+++ b/app/controllers/objectives_controller.rb
@@ -5,7 +5,7 @@ class ObjectivesController < ApplicationController
   before_action :set_objective, only: %i[show edit update destroy]
 
   def index
-    @objectives = current_user.objectives.order(order: :desc).page(params[:page]).per(5)
+    @objectives = current_user.objectives.order(order: :desc)
   end
 
   def show; end
@@ -36,6 +36,20 @@ class ObjectivesController < ApplicationController
   def destroy
     @objective.destroy
     redirect_to objectives_path, notice: t('objective.destroyed')
+  end
+
+  def move_up
+    @objective = current_user.objectives.find(params[:id])
+    @objective.move_up
+    # TODO: turbo streamで２つのobjectiveを入れ替えられないか？
+    redirect_to objectives_path, notice: t('objective.moved_up')
+  end
+
+  def move_down
+    @objective = current_user.objectives.find(params[:id])
+    @objective.move_down
+    # TODO: turbo streamで２つのobjectiveを入れ替えられないか？
+    redirect_to objectives_path, notice: t('objective.moved_down')
   end
 
   private

--- a/app/controllers/objectives_controller.rb
+++ b/app/controllers/objectives_controller.rb
@@ -41,15 +41,15 @@ class ObjectivesController < ApplicationController
 
   def move_up
     @objective = current_user.objectives.find(params[:id])
-    @objective.move_up
-    # TODO: turbo streamで２つのobjectiveを入れ替えられないか？
+    @objective.move_up!
+    # TODO: Rails 8にして、morphingでスクロール位置もキープさせたい
     redirect_to objectives_path, notice: t('objective.moved_up')
   end
 
   def move_down
     @objective = current_user.objectives.find(params[:id])
-    @objective.move_down
-    # TODO: turbo streamで２つのobjectiveを入れ替えられないか？
+    @objective.move_down!
+    # TODO: Rails 8にして、morphingでスクロール位置もキープさせたい
     redirect_to objectives_path, notice: t('objective.moved_down')
   end
 

--- a/app/models/objective.rb
+++ b/app/models/objective.rb
@@ -63,6 +63,15 @@ class Objective < ApplicationRecord
     end
   end
 
+  # バッチ処理： 古い順にorder値を1~countまでセットする
+  def self.set_orders_for_existing_objectives
+    User.find_each do |user|
+      user.objectives.order(:updated_at).each.with_index do |objective, index|
+        objective.update!(order: index)
+      end
+    end
+  end
+
   private
 
   def set_order

--- a/app/models/objective.rb
+++ b/app/models/objective.rb
@@ -37,7 +37,7 @@ class Objective < ApplicationRecord
 
   before_create :set_order
 
-  def move_up
+  def move_up!
     return if order == user.objectives.maximum(:order)
 
     Objective.transaction do
@@ -50,7 +50,7 @@ class Objective < ApplicationRecord
     end
   end
 
-  def move_down
+  def move_down!
     return if order.zero?
 
     Objective.transaction do

--- a/app/models/objective.rb
+++ b/app/models/objective.rb
@@ -42,8 +42,11 @@ class Objective < ApplicationRecord
 
     Objective.transaction do
       upper_objective = user.objectives.find_by(order: order + 1)
-      update(order: order + 1)
-      upper_objective&.update(order: order - 1)
+      return unless upper_objective
+
+      current_order = order.to_i # オブジェクトの参照から数値の参照に
+      update!(order: current_order + 1)
+      upper_objective.update!(order: current_order)
     end
   end
 
@@ -52,8 +55,11 @@ class Objective < ApplicationRecord
 
     Objective.transaction do
       lower_objective = user.objectives.find_by(order: order - 1)
-      update(order: order - 1)
-      lower_objective&.update(order: order + 1)
+      return unless lower_objective
+
+      current_order = order.to_i
+      update!(order: current_order - 1)
+      lower_objective.update!(order: current_order)
     end
   end
 

--- a/app/models/objective.rb
+++ b/app/models/objective.rb
@@ -23,6 +23,8 @@
 #
 class Objective < ApplicationRecord
   validates :objective_type, presence: true
+  validates :images, presence: true, if: :image?
+  validates :verbal, presence: true, if: :verbal?
 
   belongs_to :user
 
@@ -33,6 +35,11 @@ class Objective < ApplicationRecord
     attachable.variant :large, resize_to_limit: [400, 400]
   end
 
-  validates :images, presence: true, if: :image?
-  validates :verbal, presence: true, if: :verbal?
+  before_create :set_order
+
+  private
+
+  def set_order
+    self.order = user.objectives.count
+  end
 end

--- a/app/models/objective.rb
+++ b/app/models/objective.rb
@@ -63,15 +63,6 @@ class Objective < ApplicationRecord
     end
   end
 
-  # バッチ処理： 古い順にorder値を1~countまでセットする
-  def self.set_orders_for_existing_objectives
-    User.find_each do |user|
-      user.objectives.order(:updated_at).each.with_index do |objective, index|
-        objective.update!(order: index)
-      end
-    end
-  end
-
   private
 
   def set_order

--- a/app/models/objective.rb
+++ b/app/models/objective.rb
@@ -37,6 +37,26 @@ class Objective < ApplicationRecord
 
   before_create :set_order
 
+  def move_up
+    return if order == user.objectives.maximum(:order)
+
+    Objective.transaction do
+      upper_objective = user.objectives.find_by(order: order + 1)
+      update(order: order + 1)
+      upper_objective&.update(order: order - 1)
+    end
+  end
+
+  def move_down
+    return if order.zero?
+
+    Objective.transaction do
+      lower_objective = user.objectives.find_by(order: order - 1)
+      update(order: order - 1)
+      lower_objective&.update(order: order + 1)
+    end
+  end
+
   private
 
   def set_order

--- a/app/views/objectives/_objective_item.html.erb
+++ b/app/views/objectives/_objective_item.html.erb
@@ -1,0 +1,21 @@
+<div class="ui centered card" id="objective_<%= objective.id %>">
+  <% if objective.image? %>
+    <div class="image">
+      <%= image_tag objective.images.first.variant(:large) %>
+    </div>
+    <div class="content">
+      <div class="meta"><%= objective.comment %></div>
+      <%= render partial: 'order_icons', locals: { objective:, objectives: } %>
+    </div>
+  <% end %>
+  <% if objective.verbal? %>
+    <div class="content">
+      <div class="description"><%= objective.verbal %></div>
+      <%= render partial: 'order_icons', locals: { objective:, objectives: } %>
+    </div>
+  <% end %>
+  <%= link_to objective, class: 'ui bottom attached button', style: 'color: inherit;' do %>
+    <i class="edit icon"></i>
+    詳細
+  <% end %>
+</div>

--- a/app/views/objectives/_objective_item.html.erb
+++ b/app/views/objectives/_objective_item.html.erb
@@ -5,13 +5,13 @@
     </div>
     <div class="content">
       <div class="meta"><%= objective.comment %></div>
-      <%= render partial: 'order_icons', locals: { objective:, objectives: } %>
+      <%= render partial: 'order_icons', locals: { objective:, objectives:, maximum: } %>
     </div>
   <% end %>
   <% if objective.verbal? %>
     <div class="content">
       <div class="description"><%= objective.verbal %></div>
-      <%= render partial: 'order_icons', locals: { objective:, objectives: } %>
+      <%= render partial: 'order_icons', locals: { objective:, objectives:, maximum: } %>
     </div>
   <% end %>
   <%= link_to objective, class: 'ui bottom attached button', style: 'color: inherit;' do %>

--- a/app/views/objectives/_order_icons.html.erb
+++ b/app/views/objectives/_order_icons.html.erb
@@ -1,6 +1,6 @@
 <div class="right aligned" style="margin-top:10px" id="order_icons">
-  <%= button_to move_up_objective_path(objective), disabled: objective.order == objectives.maximum(:order), method: :patch do %>
-    <i class="angle up icon <%= 'disabled' if objective.order == objectives.maximum(:order) %>"></i>
+  <%= button_to move_up_objective_path(objective), disabled: objective.order == maximum, method: :patch do %>
+    <i class="angle up icon <%= 'disabled' if objective.order == maximum %>"></i>
   <% end %>
   <%= button_to move_down_objective_path(objective), disabled: objective.order.zero?, method: :patch do %>
     <i class="angle down icon <%= 'disabled' if objective.order.zero? %>"></i>

--- a/app/views/objectives/_order_icons.html.erb
+++ b/app/views/objectives/_order_icons.html.erb
@@ -1,0 +1,15 @@
+<div class="right aligned" style="margin-top:10px" id="order_icons">
+  <%= button_to move_up_objective_path(objective), disabled: objective.order == objectives.maximum(:order), method: :patch do %>
+    <i class="angle up icon <%= 'disabled' if objective.order == objectives.maximum(:order) %>"></i>
+  <% end %>
+  <%= button_to move_down_objective_path(objective), disabled: objective.order.zero?, method: :patch do %>
+    <i class="angle down icon <%= 'disabled' if objective.order.zero? %>"></i>
+  <% end %>
+  <i class="thumbs up outline icon"></i>
+</div> 
+
+<style>
+  #order_icons form {
+    display: inline-block;
+  }
+</style>

--- a/app/views/objectives/_order_icons.html.erb
+++ b/app/views/objectives/_order_icons.html.erb
@@ -7,9 +7,3 @@
   <% end %>
   <i class="thumbs up outline icon"></i>
 </div> 
-
-<style>
-  #order_icons form {
-    display: inline-block;
-  }
-</style>

--- a/app/views/objectives/_order_icons.html.erb
+++ b/app/views/objectives/_order_icons.html.erb
@@ -6,4 +6,4 @@
     <i class="angle down icon <%= 'disabled' if objective.order.zero? %>"></i>
   <% end %>
   <i class="thumbs up outline icon"></i>
-</div> 
+</div>

--- a/app/views/objectives/index.html.erb
+++ b/app/views/objectives/index.html.erb
@@ -17,8 +17,8 @@
         <div class="content">
           <div class="meta"><%= objective.comment %></div>
           <div class="right aligned" style="margin-top:10px">
-            <i class="angle up icon"></i>
-            <i class="angle down icon"></i>
+            <i class="angle up icon <%= 'disabled' if objective.order == @objectives.maximum(:order) %>"></i>
+            <i class="angle down icon <%= 'disabled' if objective.order.zero? %>"></i>
             <i class="thumbs up outline icon"></i>
           </div>
         </div>
@@ -27,8 +27,8 @@
         <div class="content">
           <div class="description"><%= objective.verbal %></div>
           <div class="right aligned" style="margin-top:10px">
-            <i class="angle up icon"></i>
-            <i class="angle down icon"></i>
+            <i class="angle up icon <%= 'disabled' if objective.order == @objectives.maximum(:order) %>"></i>
+            <i class="angle down icon <%= 'disabled' if objective.order.zero? %>"></i>
             <i class="thumbs up outline icon"></i>
           </div>
         </div>

--- a/app/views/objectives/index.html.erb
+++ b/app/views/objectives/index.html.erb
@@ -9,38 +9,6 @@
 <div class="ui hidden divider"></div>
 <div id="objectives">
   <% @objectives.each do |objective| %>
-    <div class="ui centered card">
-      <% if objective.image? %>
-        <div class="image">
-          <%= image_tag objective.images.first.variant(:large) %>
-        </div>
-        <div class="content">
-          <div class="meta"><%= objective.comment %></div>
-          <div class="right aligned" style="margin-top:10px">
-            <i class="angle up icon <%= 'disabled' if objective.order == @objectives.maximum(:order) %>"></i>
-            <i class="angle down icon <%= 'disabled' if objective.order.zero? %>"></i>
-            <i class="thumbs up outline icon"></i>
-          </div>
-        </div>
-      <% end %>
-      <% if objective.verbal? %>
-        <div class="content">
-          <div class="description"><%= objective.verbal %></div>
-          <div class="right aligned" style="margin-top:10px">
-            <i class="angle up icon <%= 'disabled' if objective.order == @objectives.maximum(:order) %>"></i>
-            <i class="angle down icon <%= 'disabled' if objective.order.zero? %>"></i>
-            <i class="thumbs up outline icon"></i>
-          </div>
-        </div>
-      <% end %>
-      <%= link_to objective, class: 'ui bottom attached button', style: 'color: inherit;' do %>
-        <i class="edit icon"></i>
-        詳細
-      <% end %>
-    </div>
+    <%= render partial: 'objective_item', locals: { objective:, objectives: @objectives } %>
   <% end %>
-</div>
-
-<div style="margin-top:50px; text-align:center">
-  <%= paginate @objectives %>
 </div>

--- a/app/views/objectives/index.html.erb
+++ b/app/views/objectives/index.html.erb
@@ -9,6 +9,6 @@
 <div class="ui hidden divider"></div>
 <div id="objectives">
   <% @objectives.each do |objective| %>
-    <%= render partial: 'objective_item', locals: { objective:, objectives: @objectives } %>
+    <%= render partial: 'objective_item', locals: { objective:, objectives: @objectives, maximum: @maximum } %>
   <% end %>
 </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -6,6 +6,8 @@ ja:
     created: ビジョンボードに登録しました
     updated: ビジョンボードを更新しました
     destroyed: ビジョンボードから削除しました
+    moved_up: 上に移動しました
+    moved_down: 下に移動しました
   period:
     created: 生理周期を登録しました
     updated: 生理周期を更新しました

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,13 @@ Rails.application.routes.draw do
 
   root to: "objectives#index"
 
-  resources :objectives
+  resources :objectives do
+    member do
+      patch :move_up
+      patch :move_down
+    end
+  end
+
   resources :records, only: %i[index new update]
   resource :user_setting, only: %i[show edit update]
   resources :periods

--- a/db/fixtures/development/02_objective.rb
+++ b/db/fixtures/development/02_objective.rb
@@ -1,7 +1,7 @@
 Objective.seed(:id,
                { id: 1, objective_type: 1, verbal: '服の買い物がぐっと楽しくなる', comment: '', user_id: 1, order: 0 },
                { id: 2, objective_type: 0, verbal: '', comment: '秋になったらゲットする', user_id: 1, order: 1 },
-               { id: 3, objective_type: 1, verbal: '脂肪の下に隠れた美しい筋肉', comment: '', user_id: 1, order: 2 }
+               { id: 3, objective_type: 1, verbal: '「脂肪の下に隠れた美しい筋肉を掘り起こせ」ー バズーカ岡田', comment: '', user_id: 1, order: 2 }
 )
 Objective.find(2).images.attach( io: File.open(Rails.root.join('db/images/lilith_black.png')), filename: 'lilith_black.png' )
 

--- a/lib/tasks/oneshot/set_orders_for_objectives.rake
+++ b/lib/tasks/oneshot/set_orders_for_objectives.rake
@@ -1,0 +1,10 @@
+namespace :oneshot do
+  desc '既存のobjectivesのorderの値を入れる'
+  task set_orders_for_objectives: :environment do
+    User.find_each do |user|
+      user.objectives.order(:updated_at).each.with_index do |objective, index|
+        objective.update!(order: index)
+      end
+    end
+  end
+end

--- a/spec/factories/objectives.rb
+++ b/spec/factories/objectives.rb
@@ -24,6 +24,8 @@
 FactoryBot.define do
   factory :objective do
     user
+    objective_type { :verbal }
+    verbal { Faker::JapaneseMedia::OnePiece.quote }
 
     trait :image do
       objective_type { :image }

--- a/spec/models/objective_spec.rb
+++ b/spec/models/objective_spec.rb
@@ -29,17 +29,18 @@ RSpec.describe Objective, type: :model do
   describe '#set_order' do
     context '初めてビジョンボードに登録する場合' do
       it '登録したobjectiveのorderが0になる' do
-        objective = build(:objective, user:)
-        objective.save
+        objective = create(:objective, user:)
         expect(objective.order).to eq(0)
       end
     end
 
     context 'ビジョンボードに追加する場合' do
-      it 'orderがobjectivesの数になる' do
+      before do
         4.times { create(:objective, user:) }
-        fifth_objective = create(:objective, user:)
+      end
 
+      it 'orderが作成済みobjectivesの数になる' do
+        fifth_objective = create(:objective, user:)
         expect(fifth_objective.order).to eq(4)
       end
     end
@@ -47,48 +48,62 @@ RSpec.describe Objective, type: :model do
 
   describe '#move_up!' do
     context '下に位置するobjectiveを上に移動させる場合' do
+      subject(:move_up) { objective.move_up! }
+
+      let!(:objective) { create(:objective, user:) }
+      let!(:upper_objective) { create(:objective, user:) }
+
       it 'objectiveのorderが1になる' do
-        objective = create(:objective, user:)
-        create(:objective, user:)
-        objective.move_up
-        expect(objective.reload.order).to eq(1)
+        expect { move_up }.to change { objective.reload.order }.from(0).to(1)
       end
 
       it '上のobjectiveのorderが0になる' do
-        objective = create(:objective, user:)
-        upper_objective = create(:objective, user:)
-        objective.move_up
-        expect(upper_objective.reload.order).to eq(0)
+        expect { move_up }.to change { upper_objective.reload.order }.from(1).to(0)
       end
     end
 
     context '一番上に位置するobjectiveを上に移動させる場合' do
-      it 'orderが最大のobjectiveの場合は入れ替わらない' do
+      subject(:move_up) { objective.move_up! }
+
+      before do
         4.times { create(:objective, user:) }
-        objective = create(:objective, user:)
-        objective.move_up
-        expect(objective.reload.order).to eq(4)
+      end
+
+      let(:objective) { create(:objective, user:) }
+
+      it 'orderが最大のobjectiveの場合は入れ替わらない' do
+        expect { move_up }.not_to change { objective.reload.order }.from(4)
       end
     end
   end
 
   describe '#move_down!' do
     context '上に位置するobjectiveを下に移動させる場合' do
-      it 'objectiveのorderがひとつ下のobjectiveのそれと入れ替わる' do
-        objective = create(:objective, user:)
-        lower_objective = create(:objective, user:)
-        objective.move_down
-        expect(objective.reload.order).to eq(0)
-        expect(lower_objective.reload.order).to eq(1)
+      subject(:move_down) { objective.move_down! }
+
+      let!(:lower_objective) { create(:objective, user:) }
+      let!(:objective) { create(:objective, user:) }
+
+      it 'objectiveのorderが0になる' do
+        expect { move_down }.to change { objective.reload.order }.from(1).to(0)
+      end
+
+      it '下のobjectiveのorderが1になる' do
+        expect { move_down }.to change { lower_objective.reload.order }.from(0).to(1)
       end
     end
 
     context '一番下に位置するobjectiveを下に移動させる場合' do
-      it 'orderが最小のobjectiveの場合は入れ替わらない' do
-        objective = create(:objective, user:)
+      subject(:move_down) { objective.move_down! }
+
+      let!(:objective) { create(:objective, user:) }
+
+      before do
         4.times { create(:objective, user:) }
-        objective.move_down
-        expect(objective.reload.order).to eq(0)
+      end
+
+      it 'orderが最小のobjectiveの場合は入れ替わらない' do
+        expect { move_down }.not_to change { objective.reload.order }.from(0)
       end
     end
   end

--- a/spec/models/objective_spec.rb
+++ b/spec/models/objective_spec.rb
@@ -46,36 +46,50 @@ RSpec.describe Objective, type: :model do
   end
 
   describe '#move_up' do
-    it 'objectiveのorderがひとつ上のobjectiveのそれと入れ替わる' do
-      objective = create(:objective, user:)
-      upper_objective = create(:objective, user:)
-      objective.move_up
-      expect(objective.reload.order).to eq(1)
-      expect(upper_objective.reload.order).to eq(0)
+    context '下に位置するobjectiveを上に移動させる場合' do
+      it 'objectiveのorderが1になる' do
+        objective = create(:objective, user:)
+        create(:objective, user:)
+        objective.move_up
+        expect(objective.reload.order).to eq(1)
+      end
+
+      it '上のobjectiveのorderが0になる' do
+        objective = create(:objective, user:)
+        upper_objective = create(:objective, user:)
+        objective.move_up
+        expect(upper_objective.reload.order).to eq(0)
+      end
     end
 
-    it 'orderが最大のobjectiveの場合は入れ替わらない' do
-      4.times { create(:objective, user:) }
-      objective = create(:objective, user:)
-      objective.move_up
-      expect(objective.reload.order).to eq(4)
+    context '一番上に位置するobjectiveを上に移動させる場合' do
+      it 'orderが最大のobjectiveの場合は入れ替わらない' do
+        4.times { create(:objective, user:) }
+        objective = create(:objective, user:)
+        objective.move_up
+        expect(objective.reload.order).to eq(4)
+      end
     end
   end
 
   describe '#move_down' do
-    it 'objectiveのorderがひとつ下のobjectiveのそれと入れ替わる' do
-      objective = create(:objective, user:)
-      lower_objective = create(:objective, user:)
-      objective.move_down
-      expect(objective.reload.order).to eq(0)
-      expect(lower_objective.reload.order).to eq(1)
+    context '上に位置するobjectiveを下に移動させる場合' do
+      it 'objectiveのorderがひとつ下のobjectiveのそれと入れ替わる' do
+        objective = create(:objective, user:)
+        lower_objective = create(:objective, user:)
+        objective.move_down
+        expect(objective.reload.order).to eq(0)
+        expect(lower_objective.reload.order).to eq(1)
+      end
     end
 
-    it 'orderが最小のobjectiveの場合は入れ替わらない' do
-      objective = create(:objective, user:)
-      4.times { create(:objective, user:) }
-      objective.move_down
-      expect(objective.reload.order).to eq(0)
+    context '一番下に位置するobjectiveを下に移動させる場合' do
+      it 'orderが最小のobjectiveの場合は入れ替わらない' do
+        objective = create(:objective, user:)
+        4.times { create(:objective, user:) }
+        objective.move_down
+        expect(objective.reload.order).to eq(0)
+      end
     end
   end
 end

--- a/spec/models/objective_spec.rb
+++ b/spec/models/objective_spec.rb
@@ -24,5 +24,24 @@
 require 'rails_helper'
 
 RSpec.describe Objective, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:user) { create(:user) }
+
+  describe '#set_order' do
+    context '初めてビジョンボードに登録する場合' do
+      it '登録したobjectiveのorderが0になる' do
+        objective = build(:objective, user:)
+        objective.save
+        expect(objective.order).to eq(0)
+      end
+    end
+
+    context 'ビジョンボードに追加する場合' do
+      it 'orderがobjectivesの数になる' do
+        4.times { create(:objective, user:) }
+        fifth_objective = create(:objective, user:)
+
+        expect(fifth_objective.order).to eq(4)
+      end
+    end
+  end
 end

--- a/spec/models/objective_spec.rb
+++ b/spec/models/objective_spec.rb
@@ -44,4 +44,38 @@ RSpec.describe Objective, type: :model do
       end
     end
   end
+
+  describe '#move_up' do
+    it 'objectiveのorderがひとつ上のobjectiveのそれと入れ替わる' do
+      objective = create(:objective, user:)
+      upper_objective = create(:objective, user:)
+      objective.move_up
+      expect(objective.reload.order).to eq(1)
+      expect(upper_objective.reload.order).to eq(0)
+    end
+
+    it 'orderが最大のobjectiveの場合は入れ替わらない' do
+      4.times { create(:objective, user:) }
+      objective = create(:objective, user:)
+      objective.move_up
+      expect(objective.reload.order).to eq(4)
+    end
+  end
+
+  describe '#move_down' do
+    it 'objectiveのorderがひとつ下のobjectiveのそれと入れ替わる' do
+      objective = create(:objective, user:)
+      lower_objective = create(:objective, user:)
+      objective.move_down
+      expect(objective.reload.order).to eq(0)
+      expect(lower_objective.reload.order).to eq(1)
+    end
+
+    it 'orderが最小のobjectiveの場合は入れ替わらない' do
+      objective = create(:objective, user:)
+      4.times { create(:objective, user:) }
+      objective.move_down
+      expect(objective.reload.order).to eq(0)
+    end
+  end
 end

--- a/spec/models/objective_spec.rb
+++ b/spec/models/objective_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Objective, type: :model do
     end
   end
 
-  describe '#move_up' do
+  describe '#move_up!' do
     context '下に位置するobjectiveを上に移動させる場合' do
       it 'objectiveのorderが1になる' do
         objective = create(:objective, user:)
@@ -72,7 +72,7 @@ RSpec.describe Objective, type: :model do
     end
   end
 
-  describe '#move_down' do
+  describe '#move_down!' do
     context '上に位置するobjectiveを下に移動させる場合' do
       it 'objectiveのorderがひとつ下のobjectiveのそれと入れ替わる' do
         objective = create(:objective, user:)


### PR DESCRIPTION
## 概要
- ビジョンボード画面で、アイテムの上下の表示順をスワップできる機能を実装
- close #92

## UIの変更

https://github.com/user-attachments/assets/0d6d2aa8-d3d6-48bd-9bf3-82d618cc4d7c




## 詳細
- ビジョンボード一覧画面にて、表示順をorder属性の降順に設定
- Objective modelにて、order値の設定＆orderの値を上下させる処理を追加（specも追加）
- objectives controllerにて、↑ボタン, ↓ボタンを押下した時のactionを追加（ルーティングも追加）

## その他
- 表示順の上下の処理の後はredirectさせるしかない？turbo streamで上下を入れ替えるとかはできないか？
