### PR TITLE
[CI/CD] RDSの起動処理, slackにdeployの成否通知処理を追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,11 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ap-northeast-1
 
+      - name: Start RDS DB Cluster
+        run: |
+          aws rds start-db-cluster \
+            --db-cluster-identifier ${{ secrets.RDS_CLUSTER_IDENTIFIER }}
+
       - name: Log in to ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
@@ -64,3 +69,12 @@ jobs:
                 "command": ["bundle", "exec", "rake", "ridgepole:apply"]
             }]
           }'
+
+      - name: Send Slack Message to notify deployment result
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: "#${{ secrets.SLACK_CHANNEL_ID }}",
+            text: ":seedling: ${{ github.ref_name }} : ${{ job.status }}" 


### PR DESCRIPTION
## 概要
- GitHub ActionsでのCD(デプロイ時)に、RDSの起動とslack通知を追加した
- close #97


## 詳細
- RDSは起動時間の課金が高いので、lamda functionで常時停止させているが、デプロイ時に自動起動させておくと本番環境での挙動確認時に逐一起動する手間が省けるのではと思い実装
- slack通知については、デプロイの成否の確認をAWSマネジメントコンソールの画面などを見に行かなくてもできるようにしたかったので実装

## その他