### PR TITLE
[CI/CD] slack通知ができてないのを解決

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,5 +92,5 @@ jobs:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
-            channel: "#${{ secrets.SLACK_CHANNEL_ID }}"
-            text: ":seedling: ${{ github.ref_name }} : ${{ job.status }}" 
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            text: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} : ${{ job.status }}" 


### PR DESCRIPTION
## 概要
- [PR1](https://github.com/sarii0213/lean_up/pull/98), [PR2](https://github.com/sarii0213/lean_up/pull/99)ではslack通知がされていなかったので、修正
- close #102 

## 詳細
- Slack appのscopeの問題かと思ったが、Slack Channel IDの設定が間違っていたのではと思い修正してみた
- ただ、[slack用github app](https://github.com/integrations/slack?tab=readme-ov-file#actions-workflow-notifications)を使う方が表示される情報が豊富で使い勝手良さそうなので、本PRで正常にslack通知ができることを確認したら、workflowからslack通知のstepは消して、slack用github appを使いたい。slack用github appで不便を感じるようになったら、workflowでカスタマイズしていくのが○