### PR TITLE
[CI/CD] slack通知ができてないのを解決（終）

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,12 +85,3 @@ jobs:
                 "command": ["bundle", "exec", "rake", "ridgepole:apply"]
             }]
           }'
-
-      - name: Send Slack Message to notify deployment result
-        uses: slackapi/slack-github-action@v2.0.0
-        with:
-          method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
-          payload: |
-            channel: ${{ secrets.SLACK_CHANNEL_ID }}
-            text: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} : ${{ job.status }}" 


### PR DESCRIPTION
## 概要
- slack用github appを使うことにしたので、github actionsのslack通知stepは削除


## 詳細
https://github.com/sarii0213/lean_up/pull/103 から引用
> ただ、[slack用github app](https://github.com/integrations/slack?tab=readme-ov-file#actions-workflow-notifications)を使う方が表示される情報が豊富で使い勝手良さそうなので、本PRで正常にslack通知ができることを確認したら、workflowからslack通知のstepは消して、slack用github appを使いたい。slack用github appで不便を感じるようになったら、workflowでカスタマイズしていくのが○

→ #103 のPRでslack通知ができていることを確認したので、github actions workflowsからslack通知stepは削除

