### PR TITLE
[vision board] turbo morphingを導入する

### DIFF
--- a/app/views/objectives/index.html.erb
+++ b/app/views/objectives/index.html.erb
@@ -1,3 +1,4 @@
+<% turbo_refreshes_with(method: :morph, scroll: :preserve) %>
 <div class="ui two column centered grid">
   <div class="column ui center aligned">
     <h1>vision board</h1>


### PR DESCRIPTION
## 概要
- Turbo Morphingを有効化した
- close #105

## 詳細
- Turbo Morphingを有効化することで、リダイレクト時にスクロール位置が保存されるようになった（Turbo Morphing有効化前はリダイレクト時にスクロールがトップの位置にリセットされてしまう）
- Turbo Morphingが有効化されたことで、置換対象が「bodyタグ内の全て」から「変更箇所のみ」になりパフォーマンスが上がったはず

## その他