### PR TITLE
[vision board] アップロードする画像形式のバリデーション追加

### DIFF
--- a/app/models/objective.rb
+++ b/app/models/objective.rb
@@ -44,9 +44,7 @@ class Objective < ApplicationRecord
 
     acceptable_types = %w[image/jpeg image/png image/gif image/webp]
     images.each do |image|
-      unless image.content_type.in?(acceptable_types)
-        errors.add(:images, :invalid_type)
-      end
+      errors.add(:images, :invalid_type) unless image.content_type.in?(acceptable_types)
     end
   end
 

--- a/app/models/objective.rb
+++ b/app/models/objective.rb
@@ -44,7 +44,7 @@ class Objective < ApplicationRecord
 
     acceptable_types = %w[image/jpeg image/png image/gif image/webp]
     images.each do |image|
-      if !image.content_type.in?(acceptable_types)
+      unless image.content_type.in?(acceptable_types)
         errors.add(:images, :invalid_type)
       end
     end

--- a/app/models/objective.rb
+++ b/app/models/objective.rb
@@ -25,6 +25,7 @@
 class Objective < ApplicationRecord
   validates :objective_type, presence: true
   validates :images, presence: true, if: :image?
+  validate :acceptable_images, if: :image?
   validates :verbal, presence: true, if: :verbal?
 
   belongs_to :user
@@ -37,6 +38,17 @@ class Objective < ApplicationRecord
   end
 
   before_create :set_order
+
+  def acceptable_images
+    return unless images.attached?
+
+    acceptable_types = %w[image/jpeg image/png image/gif image/webp]
+    images.each do |image|
+      if !image.content_type.in?(acceptable_types)
+        errors.add(:images, :invalid_type)
+      end
+    end
+  end
 
   def move_up!
     return if order == user.objectives.maximum(:order)

--- a/app/views/objectives/_image.html.erb
+++ b/app/views/objectives/_image.html.erb
@@ -10,6 +10,7 @@
     <% if objective.images.attached? %>
         <div style="display: flex; align-items: stretch; flex-wrap: wrap; gap: 10px;">
         <% objective.images.each do |image| %>
+            <%# 画像が存在しない場合はスキップ %>
             <% next unless image.blob_id.present? %>
             <div style="display: flex; flex-direction: column; align-items: center; justify-content: space-between; gap: 5px;" data-image-target="wrapper">
                 <%= image_tag image.variant(:thumb), data: { image_target: 'image' } %>

--- a/app/views/objectives/_image.html.erb
+++ b/app/views/objectives/_image.html.erb
@@ -10,6 +10,7 @@
     <% if objective.images.attached? %>
         <div style="display: flex; align-items: stretch; flex-wrap: wrap; gap: 10px;">
         <% objective.images.each do |image| %>
+            <% next unless image.blob_id.present? %>
             <div style="display: flex; flex-direction: column; align-items: center; justify-content: space-between; gap: 5px;" data-image-target="wrapper">
                 <%= image_tag image.variant(:thumb), data: { image_target: 'image' } %>
                 <%= form.hidden_field :images, multiple: true, value: image.signed_id %>

--- a/app/views/objectives/_image.html.erb
+++ b/app/views/objectives/_image.html.erb
@@ -9,9 +9,7 @@
     <p style="margin: 10px 0 5px;">↓ 保存済み画像 ↓</p>
     <% if objective.images.attached? %>
         <div style="display: flex; align-items: stretch; flex-wrap: wrap; gap: 10px;">
-        <% objective.images.each do |image| %>
-            <%# 画像が存在しない場合はスキップ %>
-            <% next unless image.blob_id.present? %>
+        <% objective.images.select(&:persisted?).each do |image| %>
             <div style="display: flex; flex-direction: column; align-items: center; justify-content: space-between; gap: 5px;" data-image-target="wrapper">
                 <%= image_tag image.variant(:thumb), data: { image_target: 'image' } %>
                 <%= form.hidden_field :images, multiple: true, value: image.signed_id %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -28,10 +28,11 @@ ja:
         ended_on: 終了日
     errors:
       messages:
-        record_invalid: 'バリデーションに失敗しました: %{errors}'
+        record_invalid: "バリデーションに失敗しました: %{errors}"
         restrict_dependent_destroy:
           has_one: "%{record}が存在しているので削除できません"
           has_many: "%{record}が存在しているので削除できません"
+        invalid_type: 形式が不正です
   date:
     abbr_day_names:
       - 日


### PR DESCRIPTION
## 概要
- ビジョンボードにアップロードする画像形式のバリデーションを追加
- close #118 

## UIの変更
（不正な形式の画像をアップロード後）
<img width="500" alt="スクリーンショット 2025-05-18 11 22 06" src="https://github.com/user-attachments/assets/cd12b94e-9bcc-40e9-99f9-8ae1e741bff4" />


## 詳細
- objective modelに画像のバリデーションを追加
- edit view(_image.html.erb)でblob_idのないActiveStorage::Attachmentオブジェクトは描画しないようにした（なぜロールバックされるのにActiveStorage::Blob, ActiveStorage::Attachmentが残っている？）
　-  ActiveStorage::Blob : `id: nil`, `created_at: nil`
　- ActiveStorage::Attachment : `id: nil`, `blob_id: nil`, `created_at: nil`

## その他
- Cursorでjavascriptのプライベートメソッドの書き方（`#methodName`）が直されてしまうので一旦linterオフにした。