### PR TITLE
[aws] ECS Taskが配置できない問題を解消

### DIFF
--- a/deploy/viacdn/ecs-service.yml
+++ b/deploy/viacdn/ecs-service.yml
@@ -155,7 +155,7 @@ Resources:
               ContainerPort: 3000
               Protocol: tcp
           Cpu: 0
-          MemoryReservation: 80
+          MemoryReservation: 350
           Secrets:
             - Name: RAILS_MASTER_KEY
               ValueFrom: !Sub


### PR DESCRIPTION
## 概要
- ECS Serviceにて、デプロイが失敗し続けていたのでその問題を解消
- close #160 

## 詳細
- タスク定義にて、soft limit（最低限確保されるメモリサイズ）が過小に設定されていて、それが原因でタスク配置に失敗していた模様
- エラーメッセージでは「ECS agentが接続されていない」とのことだったが、[公式のQ＆A](https://repost.aws/knowledge-center/ecs-agent-disconnected-linux2-ami)を見ると以下のように書かれていた
> It's normal for your [Amazon ECS container agent](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_agent.html) to disconnect and reconnect multiple times in an hour as part of the normal operation. These [change events](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_cwe_events.html#ecs_container_instance_events) aren't a cause for concern.
...
This issue might be caused by one of the following reasons:
...
There's resource contention in the underlying host.
