### PR TITLE
LINE連携失敗時の処理を追加

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -51,7 +51,10 @@ class User < ApplicationRecord
   # rubocop:disable Metrics/AbcSize
   def self.from_omniauth(auth, current_user = nil)
     if current_user && current_user.uid.blank?
-      current_user.update(provider: auth.provider, uid: auth.uid, email: auth.info.email, line_notify: true)
+      unless current_user.update(provider: auth.provider, uid: auth.uid, email: auth.info.email, line_notify: true)
+        return nil
+      end
+
       return current_user
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -58,7 +58,7 @@ class User < ApplicationRecord
     current_user && current_user.uid.blank?
   end
 
-  def self.link_line_account(auth, current_user = nil)
+  def self.link_line_account(auth, current_user)
     success = current_user.update(
       provider: auth.provider,
       uid: auth.uid,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -45,17 +45,13 @@ class User < ApplicationRecord
   end
 
   def line_notification_allowed?
-    uid.present? && line_notify
+    line_connected? && line_notify
   end
 
   def self.from_omniauth(auth, current_user = nil)
-    return link_line_account(auth, current_user) if linking_line_account?(current_user)
+    return link_line_account(auth, current_user) if current_user&.line_connected? == false
 
     sign_in_or_create_user_from_line(auth)
-  end
-
-  def self.linking_line_account?(current_user)
-    current_user && current_user.uid.blank?
   end
 
   def self.link_line_account(auth, current_user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,22 +48,37 @@ class User < ApplicationRecord
     uid.present? && line_notify
   end
 
-  # rubocop:disable Metrics/AbcSize
   def self.from_omniauth(auth, current_user = nil)
-    if current_user && current_user.uid.blank?
-      unless current_user.update(provider: auth.provider, uid: auth.uid, email: auth.info.email, line_notify: true)
-        return nil
-      end
+    return link_line_account(auth, current_user) if linking_line_account?(current_user)
 
-      return current_user
-    end
+    sign_in_or_create_user_from_line(auth)
+  end
 
-    # LINE連携済みのuserのusername, passwordは更新しない
-    find_or_create_by(provider: auth.provider, uid: auth.uid, email: auth.info.email) do |user|
+  def self.linking_line_account?(current_user)
+    current_user && current_user.uid.blank?
+  end
+
+  def self.link_line_account(auth, current_user = nil)
+    success = current_user.update(
+      provider: auth.provider,
+      uid: auth.uid,
+      email: auth.info.email,
+      line_notify: true
+    )
+
+    success ? current_user : nil
+  end
+
+  def self.sign_in_or_create_user_from_line(auth)
+    # LINE連携済みのuserのusername, passwordは更新されない
+    find_or_create_by(
+      provider: auth.provider,
+      uid: auth.uid,
+      email: auth.info.email
+    ) do |user|
       user.username = auth.info.name
       user.password = Devise.friendly_token[0, 20]
       user.line_notify = true
     end
   end
-  # rubocop:enable Metrics/AbcSize
 end

--- a/spec/feature/line_login_spec.rb
+++ b/spec/feature/line_login_spec.rb
@@ -82,4 +82,21 @@ RSpec.describe 'LINEログイン機能', type: :feature do
       expect(user.valid_password?('password')).to be(true)
     end
   end
+
+  context 'すでに他ユーザーでLINE連携済みのLINEアカウントに対してLINE連携を試みた場合' do
+    let(:user) { create(:user, provider: nil, uid: nil) }
+
+    before do
+      create(:user, provider: 'line', uid: line_uid, email: line_email)
+
+      login_as user
+      visit user_setting_path
+      click_button 'LINEと連携する'
+    end
+
+    it 'LINE連携に失敗する' do
+      expect(current_path).to eq(user_setting_path)
+      expect(page).to have_content('他アカウントでLINE連携済みです')
+    end
+  end
 end


### PR DESCRIPTION
## 概要
- 同一のLINEアカウントに対して異なるユーザーが連携を試みたときの処理を追加
- close #153 

## 詳細
- アプリから連携を試みたLINEアカウントがすでに連携済みのものだった場合の処理とそのspecを追加した

