### PR TITLE
[records] モーダル送信後に一瞬再度モーダルが表示されるバグを修正

### DIFF
--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -15,8 +15,7 @@ class RecordsController < ApplicationController
     @record = current_user.records.find_or_initialize_by(recorded_on: record_params[:recorded_on])
     @record.assign_attributes(record_params)
     if @record.save
-      flash[:notice] = success_message
-      render turbo_stream: turbo_stream.action(:redirect, records_path)
+      render_success
     else
       render :new, status: :unprocessable_entity
     end
@@ -26,6 +25,16 @@ class RecordsController < ApplicationController
 
   def record_params
     params.expect(record: %i[recorded_on weight body_fat])
+  end
+
+  def render_success
+    # rubocop:disable Rails/ActionControllerFlashBeforeRender
+    flash[:notice] = success_message
+    # rubocop:enable Rails/ActionControllerFlashBeforeRender
+    render turbo_stream: [
+      turbo_stream.remove('modal'),
+      turbo_stream.action(:redirect, records_path)
+    ]
   end
 
   def success_message


### PR DESCRIPTION
## 概要
- 体重記録の画面にて、フォーム送信後にモーダルが一瞬表示される問題を解決
- close #168 

## 詳細
- 問題の理由：モーダル内のフォーム送信後に、リダイレクトが起きる直前にモーダルが再表示されるのは、viewにモーダルの中身が残っているのが表示されてしまうから
- 対処：リダイレクト前に、モーダルの中身を削除

