### PR TITLE
LINE配信がprodで定期実行されていない問題を解決

### DIFF
--- a/deploy/viacdn/ecs-cluster.yml
+++ b/deploy/viacdn/ecs-cluster.yml
@@ -169,8 +169,8 @@ Resources:
             Version: !GetAtt EC2LaunchTemplate.LatestVersionNumber
           Overrides:
             ## Since the Memory is the same below, WeightedCapacity is not specified.
-            - InstanceType: t2.micro
-            - InstanceType: t3a.micro
+            - InstanceType: t3a.medium
+            - InstanceType: t3.medium
         InstancesDistribution:
           OnDemandBaseCapacity: 0
           OnDemandPercentageAboveBaseCapacity: 0

--- a/deploy/viacdn/ecs-service.yml
+++ b/deploy/viacdn/ecs-service.yml
@@ -222,6 +222,84 @@ Resources:
               max-buffer-size: 25m
           LinuxParameters:
             InitProcessEnabled: true
+        - Name: worker
+          Image: !Sub
+            - ${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${ECRRepository}:latest
+            - ECRRepository:
+                Fn::ImportValue: !Sub ${SystemName}-${Environment}-ecr-ECRRepositoryApp
+          Essential: true
+          MemoryReservation: 350
+          Secrets:
+            - Name: RAILS_MASTER_KEY
+              ValueFrom: !Sub
+                - "${SecretForRails}:RAILS_MASTER_KEY::"
+                - SecretForRails: "arn:aws:secretsmanager:ap-northeast-1:627286173480:secret:leanup/rails/config/master_key-CRoKbN"
+            - Name: DB_HOST
+              ValueFrom: !Sub
+                - "${SecretForRDSLeanup}:host::"
+                - SecretForRDSLeanup:
+                    Fn::ImportValue: !Sub ${SystemName}-${Environment}-rds-SecretForRDSLeanup
+            - Name: DB_NAME
+              ValueFrom: !Sub
+                - "${SecretForRDSLeanup}:database::"
+                - SecretForRDSLeanup:
+                    Fn::ImportValue: !Sub ${SystemName}-${Environment}-rds-SecretForRDSLeanup
+            - Name: DB_USERNAME
+              ValueFrom: !Sub
+                - "${SecretForRDSLeanup}:username::"
+                - SecretForRDSLeanup:
+                    Fn::ImportValue: !Sub ${SystemName}-${Environment}-rds-SecretForRDSLeanup
+            - Name: DB_PASSWORD
+              ValueFrom: !Sub
+                - "${SecretForRDSLeanup}:password::"
+                - SecretForRDSLeanup:
+                    Fn::ImportValue: !Sub ${SystemName}-${Environment}-rds-SecretForRDSLeanup
+            - Name: LINE_CHANNEL_ID
+              ValueFrom: !Sub
+                - "${SecretForLineLogin}:LINE_CHANNEL_ID::"
+                - SecretForLineLogin:
+                    "arn:aws:secretsmanager:ap-northeast-1:627286173480:secret:leanup/rails/config/line_login-FySttD"
+            - Name: LINE_CHANNEL_SECRET
+              ValueFrom: !Sub
+                - "${SecretForLineLogin}:LINE_CHANNEL_SECRET::"
+                - SecretForLineLogin:
+                    "arn:aws:secretsmanager:ap-northeast-1:627286173480:secret:leanup/rails/config/line_login-FySttD"
+            - Name: LINE_BOT_CHANNEL_ACCESS_TOKEN
+              ValueFrom: !Sub
+                - "${SecretForLineBot}:LINE_BOT_CHANNEL_ACCESS_TOKEN::"
+                - SecretForLineBot:
+                    "arn:aws:secretsmanager:ap-northeast-1:627286173480:secret:leanup/rails/config/line_bot_channel_access_token-oXK5Cp"
+            - Name: SLACK_BOT_TOKEN
+              ValueFrom: !Sub
+                - "${SecretForSlackBot}:SLACK_BOT_TOKEN::"
+                - SecretForSlackBot:
+                    "arn:aws:secretsmanager:ap-northeast-1:627286173480:secret:leanup/rails/config/slack_bot_token-YXbr2k"
+          Environment:
+            - Name: RAILS_CONFIG_HOSTS
+              Value: !Sub
+                - ".${DomainName}"
+                - DomainName:
+                    Fn::ImportValue: !Sub ${SystemName}-${Environment}-route53-HostedZoneDomainName
+            - Name: APP_HOST
+              Value: !Sub
+                - "https://cdn.${DomainName}"
+                - DomainName:
+                    Fn::ImportValue: !Sub ${SystemName}-${Environment}-route53-HostedZoneDomainName
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref LogsLogGroup
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: ecs
+              mode: non-blocking
+              max-buffer-size: 25m
+          Command:
+            - "bundle"
+            - "exec"
+            - "rails"
+            - "solid_queue:start"
+          LinuxParameters:
+            InitProcessEnabled: true
 
   ## ECS: Service
   Service:


### PR DESCRIPTION
## 概要
- LINE配信の定期実行がprodで正常に行われていなかったバグを解決
- close #174

## 詳細
- prodにて、run new taskでsolid queueを実行していたが、run new task は常時起動に適しておらず、solid queueが動いていなかった
- 今回はweb containerと同一taskにworker containerを追加
- web & worker containerを同一taskにするとec2 instanceのメモリがキャパオーバーになっていたのでauto scaling groupのinstance typeの指定を、メモリに余裕があるよう変更

## その他
- todo: solid queue taskを 別serviceで起動する設定（issueに追加 ✔️ ）
