### PR TITLE
[records] 期間ごとの表示切り替え機能の追加

### DIFF
--- a/app/components/chart_component.html.erb
+++ b/app/components/chart_component.html.erb
@@ -1,13 +1,13 @@
 <div data-controller="chart">
   <div data-chart-target="avgChart" style="display:block">
-    <%= line_chart average_records_for_chart, min: @minimum_record - 5, precision: 3 %>
+    <%= line_chart average_records_for_chart, min: @minimum_record - 5 %>
   </div>
   <div data-chart-target="normalChart" style="display:none">
-    <%= line_chart @records_for_chart, min: @minimum_record - 5, precision: 3 %>
+    <%= line_chart @records_for_chart, min: @minimum_record - 5 %>
   </div>
 
   <div class="ui toggle checkbox" style="margin:20px">
-    <input type="checkbox" checked data-action="chart#toggleChart">
+    <input type="checkbox" checked data-action="chart#toggleAvg">
     <label>2週間平均表示（おすすめ）</label>
   </div>
 </div>

--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -4,13 +4,6 @@ class RecordsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    since_when = case params[:timeframe]
-                 when 'one_month' then 1.month.ago
-                 when 'three_months' then 3.months.ago
-                 when 'six_months' then 6.months.ago
-                 when 'one_year' then 1.year.ago
-                 else 3.months.ago
-                 end
     @records = current_user.records.where(recorded_on: since_when..Time.zone.now).order(:recorded_on)
   end
 
@@ -32,6 +25,15 @@ class RecordsController < ApplicationController
 
   def record_params
     params.expect(record: %i[recorded_on weight body_fat])
+  end
+
+  def since_when
+    {
+      'one_month' => 1.month.ago,
+      'three_months' => 3.months.ago,
+      'six_months' => 6.months.ago,
+      'one_year' => 1.year.ago
+    }.fetch(params[:timeframe], 3.months.ago)
   end
 
   def render_success

--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -4,7 +4,14 @@ class RecordsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @records = current_user.records.order(:recorded_on)
+    since_when = case params[:timeframe]
+                 when 'one_month' then 1.month.ago
+                 when 'three_months' then 3.months.ago
+                 when 'six_months' then 6.months.ago
+                 when 'one_year' then 1.year.ago
+                 else 3.months.ago
+                 end
+    @records = current_user.records.where(recorded_on: since_when..Time.zone.now).order(:recorded_on)
   end
 
   def new

--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
 class RecordsController < ApplicationController
+  TIMEFRAME_OPTIONS = {
+    'one_month' => -> { 1.month.ago },
+    'three_months' => -> { 3.months.ago },
+    'six_months' => -> { 6.months.ago },
+    'one_year' => -> { 1.year.ago }
+  }.freeze
+  DEFAULT_TIMEFRAME = 'three_months'
+
   before_action :authenticate_user!
 
   def index
@@ -28,12 +36,8 @@ class RecordsController < ApplicationController
   end
 
   def since_when
-    {
-      'one_month' => 1.month.ago,
-      'three_months' => 3.months.ago,
-      'six_months' => 6.months.ago,
-      'one_year' => 1.year.ago
-    }.fetch(params[:timeframe], 3.months.ago)
+    timeframe_lambda = TIMEFRAME_OPTIONS[params[:timeframe] || DEFAULT_TIMEFRAME]
+    timeframe_lambda.call
   end
 
   def render_success

--- a/app/javascript/controllers/chart_controller.js
+++ b/app/javascript/controllers/chart_controller.js
@@ -8,7 +8,7 @@ export default class extends Controller {
     this.avgChartTarget.style.display = "block"
   }
 
-  toggleChart() {
+  toggleAvg() {
     this.normalChartTarget.style.display = this.normalChartTarget.style.display === "block" ? "none" : "block"
     this.avgChartTarget.style.display = this.avgChartTarget.style.display === "block" ? "none" : "block"
   }

--- a/app/views/records/_records.html.erb
+++ b/app/views/records/_records.html.erb
@@ -1,0 +1,12 @@
+<div class="ui celled horizontal list" style="display: flex; justify-content: center; margin-bottom: 15px;">
+  <% %w[one_month three_months six_months one_year].each do |timeframe| %>
+    <% selected = params[:timeframe] || 'three_months' %>
+    <%= link_to t("records.#{timeframe}"), records_path(timeframe:), class: 'item', style: "padding: 5px 10px; #{'font-weight: bold' if timeframe == selected}" %>
+  <% end %>
+</div>
+
+<% if records.present? %>
+  <%= render ChartComponent.new(records: records) %>
+<% else %>
+  <span style="display: table; margin: 30px auto">表示できる記録がありません</span>
+<% end %>

--- a/app/views/records/index.html.erb
+++ b/app/views/records/index.html.erb
@@ -5,7 +5,9 @@
     </div>
   </div>
   <div class="ui hidden divider"></div>
-  <%= render partial: 'records', locals: { records: @records } %>
+  <%= turbo_frame_tag "chart" do %>
+    <%= render partial: 'records', locals: { records: @records } %>
+  <% end %>
   <div class="ui right aligned grid">
     <div class="right floated column">
       <%= button_to new_record_path, method: :get, data: { turbo_frame: "modal" } do %>

--- a/app/views/records/index.html.erb
+++ b/app/views/records/index.html.erb
@@ -2,16 +2,10 @@
   <div class="ui two column centered grid">
     <div class="column ui center aligned">
       <h1>weight records</h1>
-      <%# TODO for future PR: 1ヶ月, 3ヶ月, 6ヶ月, 1年 の切り替えボタンを表示 -> turbo_streamでchart切り替え %>
     </div>
   </div>
   <div class="ui hidden divider"></div>
-  <div id="chart">
-    <% if @records.present? %>
-      <%= render ChartComponent.new(records: @records) %>
-    <% end %>
-  </div>
-
+  <%= render partial: 'records', locals: { records: @records } %>
   <div class="ui right aligned grid">
     <div class="right floated column">
       <%= button_to new_record_path, method: :get, data: { turbo_frame: "modal" } do %>

--- a/config/initializers/chartkick.rb
+++ b/config/initializers/chartkick.rb
@@ -2,6 +2,7 @@ Chartkick.options = {
   colors: ["#008080"],
   discrete: true,
   empty: "まだ体重記録がありません",
-  precision: 3
+  precision: 3,
+  points: false
 }
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -11,6 +11,11 @@ ja:
     destroyed: ビジョンボードから削除しました
     moved_up: 上に移動しました
     moved_down: 下に移動しました
+  records:
+    one_month: 1ヶ月
+    three_months: 3ヶ月
+    six_months: 6ヶ月
+    one_year: 1年
   period:
     created: 生理周期を登録しました
     updated: 生理周期を更新しました

--- a/db/fixtures/development/03_record.rb
+++ b/db/fixtures/development/03_record.rb
@@ -1,5 +1,9 @@
-30.times do |n|
+360.times do |n|
   Record.seed(:id,
-              { id: n + 1, user_id: 1, recorded_on: 30.days.ago + n.days , weight: rand(50.0..60.0), body_fat: rand(20.0..30.0) }
+              { id: n + 1,
+                user_id: 1,
+                recorded_on: 1.year.ago + n.days,
+                weight: rand(50.0..60.0),
+                body_fat: rand(20.0..30.0) }
   )
 end


### PR DESCRIPTION
## 概要
- 体重記録ページにて、表示する期間を４種類に切り替え可能に
- close #182 

## UIの変更
<img width="671" height="436" alt="スクリーンショット 2025-08-03 9 48 04" src="https://github.com/user-attachments/assets/2ff1e661-43d3-4994-892a-7b85b412a1dc" />


## 詳細
- 1ヶ月, 3ヶ月, 6ヶ月, 1年の４種類から表示する期間を選択すると、indexアクションにリダイレクトし、その期間の体重チャートを描画

## その他
- SQLクエリ発行回数を最小限にしてページ表示速度を最適化しようと、４種類の期間 * (平均値, 日毎の値の２種類)の計８種の体重データを一括取得してハッシュに保存しておき、jsで表示を切り替える方法を試していたが、controller, view component, jsのコードがごちゃっとしたので一旦一番シンプルな実装方法にした
