### PR TITLE
[records] 生理中の判別処理と生理中用のメッセージを追加

### DIFF
--- a/app/components/chart_component.rb
+++ b/app/components/chart_component.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ChartComponent < ViewComponent::Base
+  include Chartkick::Helper
+
   def initialize(records:)
     @records_for_chart = records.each_with_object({}) do |record, hash|
       hash[record.recorded_on.to_s] = record.weight

--- a/app/controllers/objectives_controller.rb
+++ b/app/controllers/objectives_controller.rb
@@ -42,14 +42,12 @@ class ObjectivesController < ApplicationController
   def move_up
     @objective = current_user.objectives.find(params[:id])
     @objective.move_up!
-    # TODO: Rails 8にして、morphingでスクロール位置もキープさせたい
     redirect_to objectives_path, notice: t('objective.moved_up')
   end
 
   def move_down
     @objective = current_user.objectives.find(params[:id])
     @objective.move_down!
-    # TODO: Rails 8にして、morphingでスクロール位置もキープさせたい
     redirect_to objectives_path, notice: t('objective.moved_down')
   end
 

--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -51,7 +51,7 @@ class RecordsController < ApplicationController
   end
 
   def success_message
-    message = Record::MessageGenerator.new(@record.recorded_on).generate
+    message = Record::MessageGenerator.new(@record.recorded_on, current_user).generate
     "記録完了! #{message}"
   end
 end

--- a/app/models/period.rb
+++ b/app/models/period.rb
@@ -24,12 +24,17 @@ class Period < ApplicationRecord
   belongs_to :user
 
   validates :started_on, presence: true, uniqueness: { scope: :user_id }
-  validates :ended_on, presence: true, comparison: { greater_than: :started_on }
+  validates :ended_on, comparison: { greater_than: :started_on }, if: -> { started_on.present? && ended_on.present? }
   validate :date_difference
+
+  before_validation do
+    self.ended_on = started_on.advance(weeks: 1) if ended_on.blank?
+  end
 
   private
 
   def date_difference
+    return unless started_on.present? && ended_on.present?
     return unless ended_on > started_on.advance(weeks: 2)
 
     errors.add(:ended_on, 'は開始日から2週間以内に設定してください')

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -49,15 +49,27 @@ class Record < ApplicationRecord
   end
 
   class MessageGenerator
-    def initialize(recorded_on)
+    def initialize(recorded_on, user = nil)
       @recorded_on = recorded_on
+      @user = user
     end
 
     def generate
-      # TODO: 生理周期登録機能実装後、メッセージ生成時に生理周期も参考にするように改善
       trend = Record.moving_average_trend(@recorded_on)
+      return period_message if plateau_during_period?(trend)
+
+      message_for_trend(trend)
+    end
+
+    private
+
+    def plateau_during_period?(trend)
+      trend == :plateau && @user.on_period?(@recorded_on)
+    end
+
+    def message_for_trend(trend)
       messages = { plateau: plateau_messages, smooth: smooth_messages }
-      trend ? messages[trend].sample : 'データが入るとメッセージが表示されます'
+      messages[trend]&.sample
     end
 
     def plateau_messages
@@ -66,6 +78,14 @@ class Record < ApplicationRecord
 
     def smooth_messages
       %w[減っている!!すごい!! いい調子で減量中!!]
+    end
+
+    def period_message
+      period_messages.sample
+    end
+
+    def period_messages
+      %w[プロゲステロンの影響で一時的に水分溜め込んでるだけ この時期に体重が増えるのは自然なこと ゆっくり休んで、ホルモンの荒波をやり過ごそう]
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,6 +48,10 @@ class User < ApplicationRecord
     line_connected? && line_notify
   end
 
+  def on_period?(date)
+    periods.exists?(['started_on <= ? AND ended_on >= ?', date, date])
+  end
+
   def self.from_omniauth(auth, current_user = nil)
     return link_line_account(auth, current_user) if current_user&.line_connected? == false
 

--- a/spec/models/record/message_generator_spec.rb
+++ b/spec/models/record/message_generator_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Record::MessageGenerator do
+  let(:recorded_on) { Date.new(2025, 1, 1) }
+  let(:user) { create(:user) }
+  let(:generator) { described_class.new(recorded_on, user) }
+
+  describe '#generate' do
+    context '比較データがない場合' do
+      before do
+        allow(Record).to receive(:moving_average_trend).with(recorded_on).and_return(nil)
+      end
+
+      it 'nilを返す' do
+        expect(generator.generate).to be_nil
+      end
+    end
+
+    context '体重増加傾向で生理期間中の場合' do
+      before do
+        create(:period, user:, started_on: recorded_on - 1.day, ended_on: recorded_on + 5.days)
+        allow(Record).to receive(:moving_average_trend).with(recorded_on).and_return(:plateau)
+      end
+
+      it '生理中用のメッセージを返す' do
+        expected_messages = %w[プロゲステロンの影響で一時的に水分溜め込んでるだけ この時期に体重が増えるのは自然なこと ゆっくり休んで、ホルモンの荒波をやり過ごそう]
+        expect(expected_messages).to include(generator.generate)
+      end
+    end
+
+    context '体重増加傾向で生理期間外の場合' do
+      before do
+        allow(Record).to receive(:moving_average_trend).with(recorded_on).and_return(:plateau)
+      end
+
+      it '停滞期用のメッセージを返す' do
+        expected_messages = %w[現状把握できてて偉い!! 体重とかまじでただの数字 大きな増加や停滞はだいたい水分]
+        expect(expected_messages).to include(generator.generate)
+      end
+    end
+
+    context '体重減少傾向の場合' do
+      before do
+        allow(Record).to receive(:moving_average_trend).with(recorded_on).and_return(:smooth)
+      end
+
+      it '順調期用のメッセージを返す' do
+        expected_messages = %w[減っている!!すごい!! いい調子で減量中!!]
+        expect(expected_messages).to include(generator.generate)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
- 体重記録時に表示されるメッセージに、生理中用のものを追加
- close #183 

## 詳細
- 生理期間登録時のバリデーションを修正＆コールバック追加
- 体重記録日が生理中かどうかの判定メソッドの追加
- メッセージ生成機能に生理の場合の処理を追加（spec）
