### PR TITLE
アプリのURLの"cdn"を排除

### DIFF
--- a/deploy/cloudfront.yml
+++ b/deploy/cloudfront.yml
@@ -104,7 +104,7 @@ Resources:
         # WebACLId: !FindInMap [ EnvironmentMap, !Ref Environment, WebACLArn ]
         Aliases:
           - !ImportValue
-            !Sub "${SystemName}-${Environment}-route53-HostedZoneDomainName"
+            Fn::Sub: "${SystemName}-${Environment}-route53-HostedZoneDomainName"
         ViewerCertificate:
           AcmCertificateArn: !FindInMap [ EnvironmentMap, !Ref Environment, AcmCertificateArn ]
           SslSupportMethod: sni-only

--- a/deploy/cloudfront.yml
+++ b/deploy/cloudfront.yml
@@ -33,7 +33,6 @@ Metadata:
         Parameters:
           - SystemName
           - Environment
-          - SubDomain
 
 Resources:
   ## Secrets Manager: Secret (x-via-cloudfront)
@@ -104,10 +103,8 @@ Resources:
         PriceClass: PriceClass_200
         # WebACLId: !FindInMap [ EnvironmentMap, !Ref Environment, WebACLArn ]
         Aliases:
-          - !Sub
-            - "${SubDomain}.${DomainName}"
-            - DomainName:
-                Fn::ImportValue: !Sub ${SystemName}-${Environment}-route53-HostedZoneDomainName
+          - !ImportValue
+            !Sub "${SystemName}-${Environment}-route53-HostedZoneDomainName"
         ViewerCertificate:
           AcmCertificateArn: !FindInMap [ EnvironmentMap, !Ref Environment, AcmCertificateArn ]
           SslSupportMethod: sni-only

--- a/deploy/cloudfront.yml
+++ b/deploy/cloudfront.yml
@@ -24,11 +24,6 @@ Parameters:
       - prod
       - stg
       - dev
-  SubDomain:
-    Description: Sub Domain
-    Type: String
-    Default: cdn
-    AllowedPattern: ^[^.]*$
 
 Metadata:
   AWS::CloudFormation::Interface:
@@ -268,7 +263,7 @@ Resources:
       HostedZoneId:
         Fn::ImportValue: !Sub ${SystemName}-${Environment}-route53-HostedZone
       Name: !Sub
-        - "${SubDomain}.${DomainName}."
+        - "${DomainName}."
         - DomainName:
             Fn::ImportValue: !Sub ${SystemName}-${Environment}-route53-HostedZoneDomainName
       Type: A
@@ -284,7 +279,7 @@ Resources:
       HostedZoneId:
         Fn::ImportValue: !Sub ${SystemName}-${Environment}-route53-HostedZone
       Name: !Sub
-        - "${SubDomain}.${DomainName}."
+        - "${DomainName}."
         - DomainName:
             Fn::ImportValue: !Sub ${SystemName}-${Environment}-route53-HostedZoneDomainName
       Type: AAAA

--- a/deploy/elb.yml
+++ b/deploy/elb.yml
@@ -15,11 +15,6 @@ Parameters:
       - prod
       - stg
       - dev
-  SubDomain:
-    Description: Sub Domain
-    Type: String
-    Default: elb
-    AllowedPattern: ^[^.]*$
 
 Metadata:
   AWS::CloudFormation::Interface:
@@ -29,7 +24,6 @@ Metadata:
         Parameters:
           - SystemName
           - Environment
-          - SubDomain
 
 Resources:
   ## S3: Bucket (Access Logs)
@@ -169,32 +163,6 @@ Resources:
               </html>
 
 
-  ## ELB: Listener Rule (404 Not Found)
-  ListenerRuleNotFound:
-    Type: AWS::ElasticLoadBalancingV2::ListenerRule
-    Properties:
-      ListenerArn: !Ref ListenerHttps
-      Priority: 100
-      Conditions:
-        - Field: host-header
-          HostHeaderConfig:
-            Values:
-              - !Sub
-                - "${SubDomain}.${DomainName}"
-                - DomainName:
-                    Fn::ImportValue: !Sub ${SystemName}-${Environment}-route53-HostedZoneDomainName
-      Actions:
-        - Type: fixed-response
-          FixedResponseConfig:
-            StatusCode: "404"
-            ContentType: text/html
-            MessageBody: |
-              <html>
-              <head><title>404 Not Found</title></head>
-              <body>
-              <center><h1>404 Not Found</h1></center>
-              </body>
-              </html>
 
 Outputs:
   ## S3: Bucket (Access Logs)
@@ -276,15 +244,3 @@ Outputs:
     Value: !Ref ListenerHttps
     Export:
       Name: !Sub ${AWS::StackName}-ListenerHttps
-
-  ## ELB: Listener Rule (404 Not Found)
-  ListenerRuleNotFound:
-    Value: !Ref ListenerRuleNotFound
-    Export:
-      Name: !Sub ${AWS::StackName}-ListenerRuleNotFound
-
-  ## Route 53: Record Set (IPv4)
-  Route53RecordSetIPv4:
-    Value: !Ref Route53RecordSetIPv4
-    Export:
-      Name: !Sub ${AWS::StackName}-Route53RecordSetIPv4

--- a/deploy/elb.yml
+++ b/deploy/elb.yml
@@ -196,21 +196,6 @@ Resources:
               </body>
               </html>
 
-  ## Route 53: Record Set (IPv4)
-  Route53RecordSetIPv4:
-    Type: AWS::Route53::RecordSet
-    Properties:
-      HostedZoneId:
-        Fn::ImportValue: !Sub ${SystemName}-${Environment}-route53-HostedZone
-      Name: !Sub
-        - "${SubDomain}.${DomainName}."
-        - DomainName:
-            Fn::ImportValue: !Sub ${SystemName}-${Environment}-route53-HostedZoneDomainName
-      Type: A
-      AliasTarget:
-        HostedZoneId: !GetAtt LoadBalancer.CanonicalHostedZoneID
-        DNSName: !Sub dualstack.${LoadBalancer.DNSName}
-
 Outputs:
   ## S3: Bucket (Access Logs)
   S3BucketAccessLogs:

--- a/deploy/viacdn/ecs-service.yml
+++ b/deploy/viacdn/ecs-service.yml
@@ -282,7 +282,7 @@ Resources:
                     Fn::ImportValue: !Sub ${SystemName}-${Environment}-route53-HostedZoneDomainName
             - Name: APP_HOST
               Value: !Sub
-                - "https://cdn.${DomainName}"
+                - "https://${DomainName}"
                 - DomainName:
                     Fn::ImportValue: !Sub ${SystemName}-${Environment}-route53-HostedZoneDomainName
           LogConfiguration:


### PR DESCRIPTION
## 概要
- アプリURLが`cdn.lean-up.life`となっているのを`cdn.`を消す
- close #143 

## 詳細
- Route53のA & AAAA レコードの値を修正
- CloudFront DistributionのCNAMEを修正
- アプリのURLを値とする環境変数（`APP_HOST`）を修正

## その他
- ついでに、不要なリソースを削除（インターネットからELBに直で入る経路はないので、そのDNSレコードやListener Ruleを削除）
