### PR TITLE
[periods] データがない場合にその旨を表示するよう修正

### DIFF
--- a/app/views/periods/index.html.erb
+++ b/app/views/periods/index.html.erb
@@ -15,12 +15,16 @@
     </div>
     <div class="ui card" style="width: 100%;">
       <div class="content">
-        <% @periods.each do |period| %>
-          <%= turbo_frame_tag period do %>
-            <%= render period %>
+        <% if @periods.present? %>
+          <% @periods.each do |period| %>
+            <%= turbo_frame_tag period do %>
+              <%= render period %>
+            <% end %>
           <% end %>
+        <% else %>
+          <p>no data</p>
         <% end %>
-      </div>
+        </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## 概要
- 生理期間一覧ページにて、生理データがない場合の表示が文言がなく分かりづらかったのでそれを改善
- close #228 

## UIの変更
- before
<img width="761" height="179" alt="スクリーンショット 2025-09-01 14 53 35" src="https://github.com/user-attachments/assets/32732769-c9dd-437a-8652-544975778881" />

- after
<img width="508" height="142" alt="スクリーンショット 2025-09-01 15 06 19" src="https://github.com/user-attachments/assets/4a22b738-6d48-4501-8f1b-a345c7c4bbce" />
