### PR TITLE
[LINE配信] LINEに届いた画像が表示できないバグを解消

### DIFF
--- a/deploy/viacdn/ecs-service.yml
+++ b/deploy/viacdn/ecs-service.yml
@@ -209,7 +209,7 @@ Resources:
                     Fn::ImportValue: !Sub ${SystemName}-${Environment}-route53-HostedZoneDomainName
             - Name: APP_HOST
               Value: !Sub
-                - "https://cdn.${DomainName}"
+                - "https://${DomainName}"
                 - DomainName:
                     Fn::ImportValue: !Sub ${SystemName}-${Environment}-route53-HostedZoneDomainName
           LogConfiguration:


### PR DESCRIPTION
## 概要
- アプリURLを変更してからLINE配信画像が表示されなくなっていたバグを修正
- close #229


## 詳細
- ECS Serviceのwebコンテナ（railsを動かしているコンテナ）のアプリURLを指す環境変数の値が新URLの値に変更できていなかったのを修正

## その他
- prodにてecs execコマンドで画像のLINE配信を行い、バグが解消されていることを確認した