### PR TITLE
[records] 体脂肪率グラフの表示（ユーザ設定で表示非表示切り替え）

### DIFF
--- a/app/assets/stylesheets/_toggle.scss
+++ b/app/assets/stylesheets/_toggle.scss
@@ -1,0 +1,8 @@
+.ui.toggle.checkbox input:checked ~ .box:before,
+.ui.toggle.checkbox input:checked ~ label:before {
+  background-color: #00B5AD !important;
+}
+.ui.toggle.checkbox input:focus:checked ~ .box:before,
+.ui.toggle.checkbox input:focus:checked ~ label:before {
+  background-color: #00B5AD !important;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,3 +2,4 @@
 @import 'semantic-ui';
 @import 'sp';
 @import 'objectives';
+@import 'toggle';

--- a/app/components/chart_component.html.erb
+++ b/app/components/chart_component.html.erb
@@ -1,9 +1,9 @@
 <div data-controller="chart">
   <div data-chart-target="avgChart" style="display:block">
-    <%= line_chart average_records_for_chart, min: @minimum_record - 5 %>
+    <%= line_chart average_records_for_chart, min: @minimum_record - 5, max: @maximum_record + 5 %>
   </div>
   <div data-chart-target="normalChart" style="display:none">
-    <%= line_chart @records_for_chart, min: @minimum_record - 5 %>
+    <%= line_chart @records_for_chart, min: @minimum_record - 5, max: @maximum_record + 5 %>
   </div>
 
   <div class="ui toggle checkbox" style="margin:20px">

--- a/app/components/chart_component.rb
+++ b/app/components/chart_component.rb
@@ -3,11 +3,52 @@
 class ChartComponent < ViewComponent::Base
   include Chartkick::Helper
 
-  def initialize(records:)
-    @records_for_chart = records.each_with_object({}) do |record, hash|
-      hash[record.recorded_on.to_s] = record.weight
-    end
-    @minimum_record = @records_for_chart.min_by { |a| a[1] }[1].to_i
+  # 体脂肪 表示時の出力データ： [{name:'weight', data: {'YY-MM-DD': '60', ..}},{name:'body fat', data: {...}}]
+  # 体脂肪 非表示時の出力データ： {'YY-MM-DD': '60', ..}
+  def initialize(records:, display_body_fat:)
+    @display_body_fat = display_body_fat
+    @records_for_chart =
+      if @display_body_fat
+        weight_hash =
+          records.each_with_object({}) do |record, hash|
+            hash[record.recorded_on.to_s] = record.weight
+          end
+        weight_list = { name: 'weight (kg)', data: weight_hash }
+
+        # 体重記録ｱﾘ 体脂肪率記録ﾅｼ のケースも考慮
+        body_fat_hash =
+          records.each_with_object({}) do |record, hash|
+            # binding.b
+            next unless record.body_fat.present?
+            hash[record.recorded_on.to_s] = record.body_fat
+          end
+        body_fat_list = { name: 'body fat (%)', data: body_fat_hash }
+        [weight_list, body_fat_list]
+      else
+        records.each_with_object({}) do |record, hash|
+          hash[record.recorded_on.to_s] = record.weight
+        end
+      end
+    # グラフの最小値は体脂肪率表示する場合は体脂肪率の最小値, 非表示の場合は体重の最小値
+    @minimum_record =
+      if @display_body_fat
+        body_fat_data = @records_for_chart[1][:data]
+        if body_fat_data.all? { |item| item[1].nil? }
+          weight_data = @records_for_chart[0][:data]
+          weight_data.min_by { |a| a[1] }[1].to_i
+        else
+          body_fat_data.min_by { |a| a[1] }[1].to_i
+        end
+      else
+        @records_for_chart.min_by { |a| a[1] }[1].to_i
+      end
+    @maximum_record =
+      if @display_body_fat
+        weight_data = @records_for_chart[0][:data]
+        weight_data.max_by { |a| a[1] }[1].to_i
+      else
+        @records_for_chart.max_by { |a| a[1].to_i }[1].to_i
+      end
   end
 
   def average_records_for_chart
@@ -17,20 +58,39 @@ class ChartComponent < ViewComponent::Base
   private
 
   # 2週間の移動平均を計算
-  # { '2021-01-01' => 60, '2021-01-02' => 61, ... }
   def calculate_moving_average(records)
-    sorted_records = records.sort_by { |date, _value| Date.parse(date) }
-    moving_average = {}
+    if @display_body_fat
+      # records = [{name:,data:{'date'=>num,..}},{name:,data:{'date'=>num,..}}]
+      sorted_weights = records[0][:data].sort_by { |date, _value| Date.parse(date) }
+      weight_averages = {}
+      sorted_weights.each_with_index do |record, index|
+        weight_averages[record[0]] = calculate_average_for_date(sorted_weights, index)
+      end
+      weight_average_list = { name: 'weight (kg)', data: weight_averages }
 
-    sorted_records.each_with_index do |record, index|
-      moving_average[record[0]] = calculate_average_for_date(sorted_records, index)
+      sorted_body_fats = records[1][:data].sort_by { |date, _value| Date.parse(date) }
+      body_fat_averages = {}
+      sorted_body_fats.each_with_index do |record, index|
+        next unless record.present?
+        body_fat_averages[record[0]] = calculate_average_for_date(sorted_body_fats, index)
+      end
+      body_fat_average_list = { name: 'body fat (%)', data: body_fat_averages }
+
+      [weight_average_list, body_fat_average_list]
+    else
+      sorted_records = records.sort_by { |date, _value| Date.parse(date) }
+      moving_average = {}
+
+      sorted_records.each_with_index do |record, index|
+        moving_average[record[0]] = calculate_average_for_date(sorted_records, index)
+      end
+
+      moving_average
     end
-
-    moving_average
   end
 
   def calculate_average_for_date(records, index)
-    weight_sum = 0
+    sum = 0
     count = 0
     parsed_date = Date.parse(records[index][0])
 
@@ -39,10 +99,10 @@ class ChartComponent < ViewComponent::Base
       past_date = Date.parse(record[0])
       break if parsed_date - past_date >= 14
 
-      weight_sum += record[1]
+      sum += record[1]
       count += 1
     end
 
-    weight_sum / count
+    sum / count
   end
 end

--- a/app/components/chart_component.rb
+++ b/app/components/chart_component.rb
@@ -7,48 +7,9 @@ class ChartComponent < ViewComponent::Base
   # 体脂肪 非表示時の出力データ： {'YY-MM-DD': '60', ..}
   def initialize(records:, display_body_fat:)
     @display_body_fat = display_body_fat
-    @records_for_chart =
-      if @display_body_fat
-        weight_hash =
-          records.each_with_object({}) do |record, hash|
-            hash[record.recorded_on.to_s] = record.weight
-          end
-        weight_list = { name: 'weight (kg)', data: weight_hash }
-
-        # 体重記録ｱﾘ 体脂肪率記録ﾅｼ のケースも考慮
-        body_fat_hash =
-          records.each_with_object({}) do |record, hash|
-            # binding.b
-            next unless record.body_fat.present?
-            hash[record.recorded_on.to_s] = record.body_fat
-          end
-        body_fat_list = { name: 'body fat (%)', data: body_fat_hash }
-        [weight_list, body_fat_list]
-      else
-        records.each_with_object({}) do |record, hash|
-          hash[record.recorded_on.to_s] = record.weight
-        end
-      end
-    # グラフの最小値は体脂肪率表示する場合は体脂肪率の最小値, 非表示の場合は体重の最小値
-    @minimum_record =
-      if @display_body_fat
-        body_fat_data = @records_for_chart[1][:data]
-        if body_fat_data.all? { |item| item[1].nil? }
-          weight_data = @records_for_chart[0][:data]
-          weight_data.min_by { |a| a[1] }[1].to_i
-        else
-          body_fat_data.min_by { |a| a[1] }[1].to_i
-        end
-      else
-        @records_for_chart.min_by { |a| a[1] }[1].to_i
-      end
-    @maximum_record =
-      if @display_body_fat
-        weight_data = @records_for_chart[0][:data]
-        weight_data.max_by { |a| a[1] }[1].to_i
-      else
-        @records_for_chart.max_by { |a| a[1].to_i }[1].to_i
-      end
+    @records_for_chart = records_for_chart(records)
+    @minimum_record = minimum_record
+    @maximum_record = maximum_record
   end
 
   def average_records_for_chart
@@ -57,36 +18,72 @@ class ChartComponent < ViewComponent::Base
 
   private
 
+  def records_for_chart(records)
+    if @display_body_fat
+      weight_list = { name: 'weight (kg)', data: value_hash(records, &:weight) }
+      body_fat_list = { name: 'body fat (%)', data: value_hash(records, reject_blank: true, &:body_fat) }
+      [weight_list, body_fat_list]
+    else
+      value_hash(records, &:weight)
+    end
+  end
+
+  def value_hash(records, reject_blank: false)
+    pairs = records.map { |r| [r.recorded_on.to_s, yield(r)] }
+    pairs.reject! { |_, v| v.blank? } if reject_blank
+    pairs.to_h
+  end
+
+  def minimum_record
+    # 体脂肪 非表示時の出力データ： {'YY-MM-DD': '60', ..}
+    @records_for_chart.values.compact.min.to_i unless @display_body_fat
+
+    # 体脂肪 表示時の出力データ： [{name:'weight', data: {'YY-MM-DD': '60', ..}},{name:'body fat', data: {...}}]
+    [weight_min, body_fat_min].compact.min.to_i
+  end
+
+  def weight_min
+    # weightはNOT NULLなのでnilかどうかの確認不要
+    @records_for_chart.dig(0, :data).values.compact.min
+  end
+
+  def body_fat_min
+    body_fat_data = @records_for_chart.dig(1, :data)
+    return nil unless body_fat_data
+
+    body_fat_data.values.compact.min
+  end
+
+  def maximum_record
+    @records_for_chart.values.compact.max.to_i unless @display_body_fat
+
+    @records_for_chart.dig(0, :data).values.compact.max.to_i
+  end
+
   # 2週間の移動平均を計算
   def calculate_moving_average(records)
     if @display_body_fat
-      # records = [{name:,data:{'date'=>num,..}},{name:,data:{'date'=>num,..}}]
-      sorted_weights = records[0][:data].sort_by { |date, _value| Date.parse(date) }
-      weight_averages = {}
-      sorted_weights.each_with_index do |record, index|
-        weight_averages[record[0]] = calculate_average_for_date(sorted_weights, index)
-      end
-      weight_average_list = { name: 'weight (kg)', data: weight_averages }
+      weight_records = records[0][:data]
+      weight_average_list = { name: 'weight (kg)', data: average_hash(weight_records) }
 
-      sorted_body_fats = records[1][:data].sort_by { |date, _value| Date.parse(date) }
-      body_fat_averages = {}
-      sorted_body_fats.each_with_index do |record, index|
-        next unless record.present?
-        body_fat_averages[record[0]] = calculate_average_for_date(sorted_body_fats, index)
-      end
-      body_fat_average_list = { name: 'body fat (%)', data: body_fat_averages }
+      body_fat_records = records[1][:data]
+      body_fat_average_list = { name: 'body fat (%)', data: average_hash(body_fat_records) }
 
       [weight_average_list, body_fat_average_list]
     else
-      sorted_records = records.sort_by { |date, _value| Date.parse(date) }
-      moving_average = {}
-
-      sorted_records.each_with_index do |record, index|
-        moving_average[record[0]] = calculate_average_for_date(sorted_records, index)
-      end
-
-      moving_average
+      average_hash(records)
     end
+  end
+
+  def average_hash(records)
+    sorted_records = records.sort_by { |date, _value| Date.parse(date) }
+    moving_average = {}
+
+    sorted_records.each_with_index do |record, index|
+      moving_average[record[0]] = calculate_average_for_date(sorted_records, index)
+    end
+
+    moving_average
   end
 
   def calculate_average_for_date(records, index)

--- a/app/components/chart_component.rb
+++ b/app/components/chart_component.rb
@@ -36,7 +36,7 @@ class ChartComponent < ViewComponent::Base
 
   def minimum_record
     # 体脂肪 非表示時の出力データ： {'YY-MM-DD': '60', ..}
-    @records_for_chart.values.compact.min.to_i unless @display_body_fat
+    return @records_for_chart.values.compact.min.to_i unless @display_body_fat
 
     # 体脂肪 表示時の出力データ： [{name:'weight', data: {'YY-MM-DD': '60', ..}},{name:'body fat', data: {...}}]
     [weight_min, body_fat_min].compact.min.to_i
@@ -55,7 +55,7 @@ class ChartComponent < ViewComponent::Base
   end
 
   def maximum_record
-    @records_for_chart.values.compact.max.to_i unless @display_body_fat
+    return @records_for_chart.values.compact.max.to_i unless @display_body_fat
 
     @records_for_chart.dig(0, :data).values.compact.max.to_i
   end

--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -13,6 +13,7 @@ class RecordsController < ApplicationController
 
   def index
     @records = current_user.records.where(recorded_on: since_when..Time.zone.now).order(:recorded_on)
+    @display_body_fat = current_user.display_body_fat
   end
 
   def new

--- a/app/views/records/_records.html.erb
+++ b/app/views/records/_records.html.erb
@@ -6,7 +6,7 @@
 </div>
 
 <% if records.present? %>
-  <%= render ChartComponent.new(records: records) %>
+  <%= render ChartComponent.new(records: records, display_body_fat: display_body_fat) %>
 <% else %>
   <span style="display: table; margin: 30px auto">表示できる記録がありません</span>
 <% end %>

--- a/app/views/records/index.html.erb
+++ b/app/views/records/index.html.erb
@@ -6,7 +6,7 @@
   </div>
   <div class="ui hidden divider"></div>
   <%= turbo_frame_tag "chart" do %>
-    <%= render partial: 'records', locals: { records: @records } %>
+    <%= render partial: 'records', locals: { records: @records, display_body_fat: @display_body_fat } %>
   <% end %>
   <div class="ui right aligned grid">
     <div class="right floated column">


### PR DESCRIPTION
## 概要
- 体重グラフに、体脂肪率も表示できるようにした
- close #231 

## UIの変更
体脂肪率表示なし
<img width="499" height="461" alt="スクリーンショット 2025-09-04 20 00 02" src="https://github.com/user-attachments/assets/2d1570fc-9df3-4f01-a959-2ca34e284913" />

---

体脂肪率表示あり
<img width="507" height="464" alt="スクリーンショット 2025-09-04 19 59 55" src="https://github.com/user-attachments/assets/01cfa2a8-f482-4980-ba7d-40bb461df3bf" />


## 詳細
- ユーザ設定の体脂肪率表示の有無によって、グラフ描画用データの生成処理を分岐
- デフォルトのtoggleの色が合っていなかったので、ついでに修正

## その他

