### PR TITLE
LINE APIリクエストエラー時のslack通知を非同期化

### DIFF
--- a/app/jobs/push_slack_job.rb
+++ b/app/jobs/push_slack_job.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class PushSlackJob < ApplicationJob
+  queue_as :default
+
+  DEFAULT_CHANNEL = '#general'
+
+  def perform(context)
+    client = Slack::Web::Client.new
+    client.chat_postMessage(
+      channel: DEFAULT_CHANNEL,
+      text: 'message from slack error subscriber',
+      blocks: build_message_blocks(context)
+    )
+  end
+
+  private
+
+  def build_message_blocks(context)
+    [
+      build_header_block(context[:action]),
+      build_divider_block,
+      build_details_block(context.except(:action))
+    ]
+  end
+
+  def build_header_block(action)
+    {
+      type: 'header',
+      text: {
+        type: 'plain_text',
+        text: ":bell: #{action}"
+      }
+    }
+  end
+
+  def build_divider_block
+    { type: 'divider' }
+  end
+
+  def build_details_block(details)
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: format_details(details)
+      }
+    }
+  end
+
+  def format_details(details)
+    details.map { |key, value| "*#{key}*: #{value}" }.join("\n")
+  end
+end

--- a/app/subscribers/slack_error_subscriber.rb
+++ b/app/subscribers/slack_error_subscriber.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
 class SlackErrorSubscriber
-  DEFAULT_CHANNEL = '#general'
-
   def report(_error, context:, **)
     if Rails.env.production?
-      send_slack_message(context)
+      PushSlackJob.perform_later(context)
     else
       log_error(context)
     end
@@ -13,52 +11,7 @@ class SlackErrorSubscriber
 
   private
 
-  def send_slack_message(context)
-    client = Slack::Web::Client.new
-    client.chat_postMessage(
-      channel: DEFAULT_CHANNEL,
-      text: 'message from slack error subscriber',
-      blocks: build_message_blocks(context)
-    )
-  end
-
   def log_error(context)
     Rails.logger.info("SlackErrorSubscriber has subscribed to this error:\ncontext: #{context}")
-  end
-
-  def build_message_blocks(context)
-    [
-      build_header_block(context[:action]),
-      build_divider_block,
-      build_details_block(context.except(:action))
-    ]
-  end
-
-  def build_header_block(action)
-    {
-      type: 'header',
-      text: {
-        type: 'plain_text',
-        text: ":bell: #{action}"
-      }
-    }
-  end
-
-  def build_divider_block
-    { type: 'divider' }
-  end
-
-  def build_details_block(details)
-    {
-      type: 'section',
-      text: {
-        type: 'mrkdwn',
-        text: format_details(details)
-      }
-    }
-  end
-
-  def format_details(details)
-    details.map { |key, value| "*#{key}*: #{value}" }.join("\n")
   end
 end

--- a/spec/subscribers/slack_error_subscriber_spec.rb
+++ b/spec/subscribers/slack_error_subscriber_spec.rb
@@ -4,6 +4,8 @@ require 'rails_helper'
 require Rails.root.join('app/subscribers/slack_error_subscriber')
 
 RSpec.describe SlackErrorSubscriber, type: :feature do
+  include ActiveJob::TestHelper
+
   let(:error) { StandardError.new('error message') }
   let(:slack_client) { instance_double(Slack::Web::Client) }
 
@@ -24,7 +26,7 @@ RSpec.describe SlackErrorSubscriber, type: :feature do
       let(:access_token) { { id_token: '11111' } }
 
       it 'エラー内容をSlackに通知する' do
-        Rails.error.report(error, context:)
+        perform_enqueued_jobs { Rails.error.report(error, context:) }
 
         expect(slack_client).to have_received(:chat_postMessage) do |args|
           expect(args[:blocks]).to(be_any { |b| b.dig(:text, :text)&.include?('LINE login') })
@@ -44,7 +46,7 @@ RSpec.describe SlackErrorSubscriber, type: :feature do
       let(:objective) { create(:objective, user:) }
 
       it 'エラー内容をSlackに通知する' do
-        Rails.error.report(error, context:)
+        perform_enqueued_jobs { Rails.error.report(error, context:) }
 
         expect(slack_client).to have_received(:chat_postMessage) do |args|
           expect(args[:blocks]).to(be_any { |b| b.dig(:text, :text)&.include?('LINE delivery') })
@@ -62,7 +64,7 @@ RSpec.describe SlackErrorSubscriber, type: :feature do
       let(:user) { create(:user, provider: 'line', uid: '1234567') }
 
       it 'エラー内容をSlackに通知する' do
-        Rails.error.report(error, context:)
+        perform_enqueued_jobs { Rails.error.report(error, context:) }
 
         expect(slack_client).to have_received(:chat_postMessage) do |args|
           expect(args[:blocks]).to(be_any { |b| b.dig(:text, :text)&.include?('LINE delivery test') })


### PR DESCRIPTION
## 概要
- APIリクエストエラー時のslack配信を非同期ジョブ化
- close #163


## 詳細
- APIリクエスト（現状：LINEログイン/配信）に失敗した場合に行われるslack配信を非同期化した

## その他

